### PR TITLE
[FEATURE] Make it possible to disable binary copy to root

### DIFF
--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -36,6 +36,7 @@ class InstallerScripts
      * @param ScriptEvent $event
      * @param bool $calledFromPlugin
      * @return void
+     * @throws \RuntimeException
      */
     public static function setupConsole(ScriptEvent $event, $calledFromPlugin = false)
     {
@@ -57,6 +58,10 @@ class InstallerScripts
                 $filesystem->ensureDirectoryExists($extDir);
                 $filesystem->symlink($installDir, $consoleDir);
             }
+        }
+        $pluginConfig = \Helhum\Typo3ConsolePlugin\Config::load($event->getIO(), $event->getComposer()->getConfig());
+        if (!$pluginConfig->get('install-binary')) {
+            return;
         }
         // @deprecated. can be removed once the typo3 installer takes care of installing binaries
         if (self::isWindowsOs()) {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "ext-Phar": "*",
         "php": ">=5.5.0",
-        "helhum/typo3-console-plugin": "^1.0.0",
+        "helhum/typo3-console-plugin": "^1.3.0",
         "typo3/cms-core": "^7.6 || ^8.0",
         "symfony/console": "^2.7 || ^3.1",
         "symfony/process": "^2.7 || ^3.1"


### PR DESCRIPTION
As composer now can take care to copy (or link) the binaries,
we can add an option to not additionally copy the binary
to the root directory.

This option is "install-binary" in the plugin config
and is on by default so that third party libraries can adopt the new location.