### PR TITLE
The cli-command "extension:install" should behave like an installation in the extensionmanager

### DIFF
--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -66,37 +66,38 @@ class ExtensionCommandController extends CommandController
      */
     public function activateCommand(array $extensionKeys)
     {
-        $this->emitPackagesMayHaveChangedSignal();
-        $installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
+		$this->emitPackagesMayHaveChangedSignal();
+		$installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
 
-        $extensionKeysAsString = implode('", "', $extensionKeys);
-        foreach ($extensionKeys as $extensionKey) {
-                try {
-                        if (in_array($extensionKey, $installedExtensions)) {
-                                continue; 
-			}
+		$extensionKeysAsString = implode('", "', $extensionKeys);
+		foreach ($extensionKeys as $extensionKey) {
+			try {
+				if (in_array($extensionKey, $installedExtensions)) {
+					continue; 
+				}
 				
-                        $extension = $this->extensionModelUtility->mapExtensionArrayToModel(
-                                $this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
-                        );
-                        if ($this->managementService->installExtension($extension) === false) {
-                                $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
-                                $this->sendAndExit(2);
-                        }
-                }
-                catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
-                        $this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-                        $this->sendAndExit(2);
-                } catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
-                        $this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-                        $this->sendAndExit(2);
-                }
+				$extension = $this->extensionModelUtility->mapExtensionArrayToModel(
+					$this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
+				);
+				
+				if ($this->managementService->installExtension($extension) === false) {
+					$this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
+					$this->sendAndExit(2);
+				}
+			}
+			catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
+				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+				$this->sendAndExit(2);
+			} catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
+				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+				$this->sendAndExit(2);
+			}
         }
 	
-        if (count($extensionKeys) === 1) {
-                $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
+		if (count($extensionKeys) === 1) {
+			$this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
         } else {
-                $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);
+            $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);
         }
     }
 

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -67,31 +67,33 @@ class ExtensionCommandController extends CommandController
     public function activateCommand(array $extensionKeys)
     {
         $this->emitPackagesMayHaveChangedSignal();
-		$installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
+	$installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
+	
+	$extensionKeysAsString = implode('", "', $extensionKeys);
         foreach ($extensionKeys as $extensionKey) {
-			try {
-				if (in_array($extensionKey, $installedExtensions)) {
-					continue; 
-				}
-				
-				$extension = $this->extensionModelUtility->mapExtensionArrayToModel(
-					$this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
-				);
-				if ($this->managementService->installExtension($extension) === false) {
-					 $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
-					 $this->sendAndExit(2);
-				}
+		try {
+			if (in_array($extensionKey, $installedExtensions)) {
+				continue; 
 			}
-			catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
-				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-				$this->sendAndExit(2);
-			} catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
-				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-				$this->sendAndExit(2);
+				
+			$extension = $this->extensionModelUtility->mapExtensionArrayToModel(
+				$this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
+			);
+			if ($this->managementService->installExtension($extension) === false) {
+				 $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
+				 $this->sendAndExit(2);
 			}
 		}
+		catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
+			$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+			$this->sendAndExit(2);
+		} catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
+			$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+			$this->sendAndExit(2);
+		}
+	}
 		
-		if (count($extensionKeys) === 1) {
+	if (count($extensionKeys) === 1) {
             $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
         } else {
             $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -66,36 +66,36 @@ class ExtensionCommandController extends CommandController
      */
     public function activateCommand(array $extensionKeys)
     {
-		$this->emitPackagesMayHaveChangedSignal();
-		$installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
+        $this->emitPackagesMayHaveChangedSignal();
+        $installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
 
-		$extensionKeysAsString = implode('", "', $extensionKeys);
-		foreach ($extensionKeys as $extensionKey) {
-			try {
-				if (in_array($extensionKey, $installedExtensions)) {
-					continue; 
-				}
-				
-				$extension = $this->extensionModelUtility->mapExtensionArrayToModel(
-					$this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
-				);
-				
-				if ($this->managementService->installExtension($extension) === false) {
-					$this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
-					$this->sendAndExit(2);
-				}
-			}
-			catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
-				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-				$this->sendAndExit(2);
-			} catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
-				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-				$this->sendAndExit(2);
-			}
+        $extensionKeysAsString = implode('", "', $extensionKeys);
+        foreach ($extensionKeys as $extensionKey) {
+            try {
+                if (in_array($extensionKey, $installedExtensions)) {
+                    continue; 
+                }
+
+                $extension = $this->extensionModelUtility->mapExtensionArrayToModel(
+                    $this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
+                );
+
+                if ($this->managementService->installExtension($extension) === false) {
+                    $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
+                    $this->sendAndExit(2);
+                }
+            }
+            catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
+                $this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+                $this->sendAndExit(2);
+            } catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
+                $this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+                $this->sendAndExit(2);
+            }
         }
 	
-		if (count($extensionKeys) === 1) {
-			$this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
+        if (count($extensionKeys) === 1) {
+            $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
         } else {
             $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);
         }

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -37,6 +37,18 @@ class ExtensionCommandController extends CommandController
      */
     protected $extensionInstaller;
 
+	/**
+     * @var \TYPO3\CMS\Extensionmanager\Utility\ExtensionModelUtility
+     * @inject
+     */
+    protected $extensionModelUtility;
+	
+	/**
+     * @var \TYPO3\CMS\Extensionmanager\Service\ExtensionManagementService
+	 * @inject
+     */
+    protected $managementService;
+
     /**
      * @var \TYPO3\CMS\Core\Package\PackageManager
      * @inject
@@ -55,11 +67,31 @@ class ExtensionCommandController extends CommandController
     public function activateCommand(array $extensionKeys)
     {
         $this->emitPackagesMayHaveChangedSignal();
+		$installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
         foreach ($extensionKeys as $extensionKey) {
-            $this->extensionInstaller->install($extensionKey);
-        }
-        $extensionKeysAsString = implode('", "', $extensionKeys);
-        if (count($extensionKeys) === 1) {
+			try {
+				if (in_array($extensionKey, $installedExtensions)) {
+					continue; 
+				}
+				
+				$extension = $this->extensionModelUtility->mapExtensionArrayToModel(
+					$this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
+				);
+				if ($this->managementService->installExtension($extension) === false) {
+					 $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
+					 $this->sendAndExit(2);
+				}
+			}
+			catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
+				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+				$this->sendAndExit(2);
+			} catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
+				$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+				$this->sendAndExit(2);
+			}
+		}
+		
+		if (count($extensionKeys) === 1) {
             $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
         } else {
             $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -67,36 +67,36 @@ class ExtensionCommandController extends CommandController
     public function activateCommand(array $extensionKeys)
     {
         $this->emitPackagesMayHaveChangedSignal();
-	$installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
-	
-	$extensionKeysAsString = implode('", "', $extensionKeys);
+        $installedExtensions = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getLoadedExtensionListArray();
+
+        $extensionKeysAsString = implode('", "', $extensionKeys);
         foreach ($extensionKeys as $extensionKey) {
-		try {
-			if (in_array($extensionKey, $installedExtensions)) {
-				continue; 
+                try {
+                        if (in_array($extensionKey, $installedExtensions)) {
+                                continue; 
 			}
 				
-			$extension = $this->extensionModelUtility->mapExtensionArrayToModel(
-				$this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
-			);
-			if ($this->managementService->installExtension($extension) === false) {
-				 $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
-				 $this->sendAndExit(2);
-			}
-		}
-		catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
-			$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-			$this->sendAndExit(2);
-		} catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
-			$this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
-			$this->sendAndExit(2);
-		}
-	}
-		
-	if (count($extensionKeys) === 1) {
-            $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
+                        $extension = $this->extensionModelUtility->mapExtensionArrayToModel(
+                                $this->extensionInstaller->enrichExtensionWithDetails($extensionKey)
+                        );
+                        if ($this->managementService->installExtension($extension) === false) {
+                                $this->outputLine('<error>Extension "%s" could not be installed.</error>', [$extensionKey]);
+                                $this->sendAndExit(2);
+                        }
+                }
+                catch (\TYPO3\CMS\Extensionmanager\Exception\ExtensionManagerException $e) {
+                        $this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+                        $this->sendAndExit(2);
+                } catch (\TYPO3\CMS\Core\Package\Exception\PackageStatesFileNotWritableException $e) {
+                        $this->outputLine('<error>There was an exception: "%s".</error>', [$e->getMessage()]);
+                        $this->sendAndExit(2);
+                }
+        }
+	
+        if (count($extensionKeys) === 1) {
+                $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);
         } else {
-            $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);
+                $this->outputLine('<info>Extensions "%s" are now active.</info>', [$extensionKeysAsString]);
         }
     }
 


### PR DESCRIPTION
Currently you can activate extensions which require other extension(s), but the required extension doesn't get activated itself. This leads to errors, like not importing records or an unusable extensionmanager (error because of the dependency).

For example: 
I have an extension which builds on top of ig_ldap_sso_auth and requires it in the em_conf and composer.json. It imports an ig_ldap_sso_auth record into the corresponding table (data.t3d). If you want to activate this extension with cli then you have to activate the requirements first, so you have to do:
```
typo3cms extension:activate --extension-keys=ig_ldap_sso_auth
typo3cms extension:activate --extension-keys=my_ldap_extension
```
or
`typo3cms extension:activate --extension-keys=ig_ldap_sso_auth, my_ldap_extension`
If you only activate my_ldap_extension or activate it first then it will fail importing the record,
because the needed table was not created.

This can be solved by using the logic of the extensionmanager:
`\TYPO3\CMS\Extensionmanager\Controller\ActionController->toggleExtensionInstallationStateAction`
