### PR TITLE
[TASK] Add requires for typo3/cms framework packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,16 @@
         "ext-Phar": "*",
         "php": ">=5.5.0",
         "helhum/typo3-console-plugin": "^1.3.0",
+
+        "typo3/cms-backend": "^7.6 || ^8.0",
         "typo3/cms-core": "^7.6 || ^8.0",
+        "typo3/cms-extbase": "^7.6 || ^8.0",
+        "typo3/cms-extensionmanager": "^7.6 || ^8.0",
+        "typo3/cms-fluid": "^7.6 || ^8.0",
+        "typo3/cms-install": "^7.6 || ^8.0",
+        "typo3/cms-saltedpasswords": "^7.6 || ^8.0",
+        "typo3/cms-scheduler": "^7.6 || ^8.0",
+
         "symfony/console": "^2.7 || ^3.1",
         "symfony/process": "^2.7 || ^3.1"
     },


### PR DESCRIPTION
The console in fact does not depend on the complete
typo3/cms package, but only on a few framework packages.

Point that out by adding them to the require section.