### PR TITLE
[TASK] Streamline auto completion script

### DIFF
--- a/Classes/Command/HelpCommandController.php
+++ b/Classes/Command/HelpCommandController.php
@@ -209,6 +209,12 @@ class HelpCommandController extends CommandController
         $commandsOptions = [];
         $commands = [];
         foreach ($this->commands as $commandIdentifier => $command) {
+            $commandIdentifier = strtolower($commandIdentifier);
+            if ($commandIdentifier === 'help:autocomplete') {
+                $commandIdentifier = 'autocomplete';
+            } elseif ($commandIdentifier === 'help:help') {
+                $commandIdentifier = 'help';
+            }
             $commands[] = $commandIdentifier;
             $commandsDescriptions[$commandIdentifier] = $command->getShortDescription();
             $commandsOptionsDescriptions[$commandIdentifier] = [];

--- a/Classes/Mvc/Cli/CommandManager.php
+++ b/Classes/Mvc/Cli/CommandManager.php
@@ -50,6 +50,18 @@ class CommandManager extends \TYPO3\CMS\Extbase\Mvc\Cli\CommandManager
     }
 
     /**
+     * @param string $commandIdentifier
+     * @return \TYPO3\CMS\Extbase\Mvc\Cli\Command
+     */
+    public function getCommandByIdentifier($commandIdentifier)
+    {
+        if ($commandIdentifier === 'autocomplete') {
+            $commandIdentifier = 'extbase:help:autocomplete';
+        }
+        return parent::getCommandByIdentifier($commandIdentifier);
+    }
+
+    /**
      * Make sure the object manager is set
      *
      * @return \TYPO3\CMS\Extbase\Mvc\Cli\Command[]

--- a/Resources/Private/AutocompleteTemplates/cached.bash.tpl
+++ b/Resources/Private/AutocompleteTemplates/cached.bash.tpl
@@ -36,7 +36,7 @@ _%%SCRIPT%%()
     fi
 
     # completing for a command
-    if [[ $cur == $com ]]; then
+    if [[ $cur == $com  || $com == "help" ]]; then
         coms="%%COMMANDS%%"
 
         COMPREPLY=($(compgen -W "${coms}" -- ${cur}))

--- a/Resources/Private/AutocompleteTemplates/cached.zsh.tpl
+++ b/Resources/Private/AutocompleteTemplates/cached.zsh.tpl
@@ -17,7 +17,7 @@ _%%SCRIPT%%()
     if [[ ${cur} == --* ]]; then
         state="option"
         opts=(%%SHARED_OPTIONS%%)
-    elif [[ $cur == $com ]]; then
+    elif [[ $cur == $com || $com == "help" ]]; then
         state="command"
         coms=(%%COMMANDS%%)
     fi


### PR DESCRIPTION
* Make "help:help" just "help
* Make commands all lower case
* Complete commands for help command
* Alias help:autocomplete to just autocomplete