### PR TITLE
[BUGFIX] Avoid fatal when groups not provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,9 @@ script:
   - ./typo3cms backend:lockforeditors
   - ./typo3cms backend:unlockforeditors
   - ./typo3cms cache:flush
+  - ./typo3cms cache:flushgroups pages
+  - ./typo3cms cache:flushtags foo
+  - ./typo3cms cache:flushtags foo pages
   - ./typo3cms cache:listgroups
   - ./typo3cms cleanup:updatereferenceindex
   - ./typo3cms database:updateschema "*" --verbose

--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -89,7 +89,11 @@ class CacheCommandController extends CommandController
     {
         try {
             $this->cacheService->flushByTagsAndGroups($tags, $groups);
-            $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '" in groups: "' . implode('","', $groups) . '"');
+            if ($groups === null) {
+                $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '"');
+            } else {
+                $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '" in groups: "' . implode('","', $groups) . '"');
+            }
         } catch (NoSuchCacheGroupException $e) {
             $this->outputLine($e->getMessage());
             $this->sendAndExit(1);


### PR DESCRIPTION
If $groups is null, then the implode causes a warning
which is converted into an exception.