### PR TITLE
[BUGFIX] Fix library build command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "extension-create-libs": [
             "mkdir -p Libraries/temp",
             "[ -f $HOME/.composer/vendor/bin/phar-composer ] || composer global require clue/phar-composer",
-            "[ -f Libraries/symfony-process.phar ] || cd Libraries/temp && composer require symfony/process=~2.7.0 && composer config classmap-authoritative true && composer config prepend-autoloader false && composer dump-autoload",
+            "if [ ! -f Libraries/symfony-process.phar ]; then cd Libraries/temp && composer require symfony/process=~2.7.0 && composer config classmap-authoritative true && composer config prepend-autoloader false && composer dump-autoload; fi",
             "[ -f Libraries/symfony-process.phar ] || $HOME/.composer/vendor/bin/phar-composer build Libraries/temp/ Libraries/symfony-process.phar",
             "chmod -x Libraries/*.phar",
             "rm -rf Libraries/temp"


### PR DESCRIPTION
The construct with just "||" did not work in the case
the library is already built. Replace that with "if"