### PR TITLE
[BUGFIX] Flush cache directory on force flush

### DIFF
--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -153,11 +153,9 @@ class CacheService implements SingletonInterface
     protected function forceFlushCoreFileAndDatabaseCaches()
     {
         // @deprecated Will be removed once TYPO3 7.6 support is removed
-        if (is_dir(PATH_site . 'typo3temp/Cache')) {
-            GeneralUtility::rmdir(PATH_site . 'typo3temp/Cache', true);
-        }
+        GeneralUtility::flushDirectory(PATH_site . 'typo3temp/Cache', true);
         // Delete typo3temp/Cache
-        GeneralUtility::rmdir(PATH_site . 'typo3temp/var/Cache', true);
+        GeneralUtility::flushDirectory(PATH_site . 'typo3temp/var/Cache', true);
         // Get all table names starting with 'cf_' and truncate them
         $tables = $this->databaseConnection->admin_get_tables();
         foreach ($tables as $table) {


### PR DESCRIPTION
Instead of simply removing the cache directory on force flush,
it should be flushed instead which first moves the directory to
a temporary path and then removes it. This helps avoiding race
conditions on concurrent requests.