### PR TITLE
[BUGFIX] Do not show cache:flush when T3 not installed

### DIFF
--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -269,7 +269,10 @@ class RunLevel
         $availableRunlevel = $this->getMaximumAvailableRunLevel();
         $isAvailable = true;
         if ($availableRunlevel === self::LEVEL_COMPILE) {
-            if (in_array($expectedRunLevel, array(self::LEVEL_FULL, self::LEVEL_MINIMAL))) {
+            if (in_array($expectedRunLevel, array(self::LEVEL_FULL, self::LEVEL_MINIMAL), true)) {
+                $isAvailable = false;
+            } elseif ($commandIdentifier === 'cache:flush') {
+                // @TODO: find a nicer way to hide this command when TYPO3 is not installed yet
                 $isAvailable = false;
             }
         }


### PR DESCRIPTION
cache:flush command needs to be in low runlevel
to not load extension files before clearing caches.
However it is also not useful when TYPO3 is not installed yet.

Thus we just hide it until we have a nicer bootstrap,
TYPO3 does not need extension caching any more or some
other nicer solution magically appears.

Fixes #281