### PR TITLE
[BUGFIX] Make configuration commands work without DB

### DIFF
--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -18,6 +18,7 @@ return array(
         'typo3_console:install:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
         'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
         'typo3_console:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
+        'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
     ),
     'bootingSteps' => array(
         'typo3_console:install:databasedata' => array(


### PR DESCRIPTION
The configuration commands only need configuration
to be bootstrapped, and not the database connection
to be initialized. We can thus allow the commands to works
with a minimal bootstrap.

Fixes #292