### PR TITLE
[BUGFIX] Move lower bound for symfony versions to installable one (#299)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "typo3/cms-saltedpasswords": "^7.6 || ^8.0",
         "typo3/cms-scheduler": "^7.6 || ^8.0",
 
-        "symfony/console": "^2.7 || ^3.1",
-        "symfony/process": "^2.7 || ^3.1"
+        "symfony/console": "^2.7 || ^3.0",
+        "symfony/process": "^2.7 || ^3.0"
     },
     "require-dev": {
         "namelesscoder/typo3-repository-client": "^1.2.0",


### PR DESCRIPTION
The introduced upper bound in #187 was good, but it was not taken in
mind, that the lower bound was bumped too, which prevents installing
the latest TYPO3 8.3.x version and composer wants to fall back to TYPO3
8.3.0, which is insecure.