### PR TITLE
[BUGFIX] Do not try to insert data if action failed

### DIFF
--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -124,7 +124,7 @@ class CliSetupRequestHandler
         // TODO: provide pre- and post-execute signals?
         $messages = $this->executeAction($this->createActionWithNameAndArguments($actionName, $arguments));
         // TODO: ultimately get rid of that!
-        if ($actionName === 'databaseData') {
+        if ($messages === [] && $actionName === 'databaseData') {
             /** @var DatabaseConnection $db */
             $db = $GLOBALS['TYPO3_DB'];
             $db->exec_INSERTquery('be_users', array('username' => '_cli_lowlevel'));


### PR DESCRIPTION
If the database step fails for whatever reason, we must not
try to insert something into the database because the tables
might not exist yet, but just let the error message bubble up

Fixes #302