### PR TITLE
[BUGFIX] Use confirmation dialogue for bool arguments

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -197,7 +197,7 @@ class InstallCommandController extends CommandController
      *
      * Select a database by name
      *
-     * @param bool $useExistingDatabase Use existing database (1), or create database (0)
+     * @param bool $useExistingDatabase Use already existing database?
      * @param string $databaseName Name of the database
      * @internal
      */

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -238,20 +238,30 @@ class CliSetupRequestHandler
                     }
                     $argumentValue = null;
                     do {
-                        if ($isPasswordArgument) {
+                        $defaultValue = $argument->getDefaultValue();
+                        $isRequired = $this->isArgumentRequired($argument);
+                        if ($isPasswordArgument && $isRequired) {
                             $argumentValue = $this->output->askHiddenResponse(
+                                sprintf(
+                                    '<comment>%s:</comment> ',
+                                    $argumentDefinition->getDescription()
+                                )
+                            );
+                        } elseif (is_bool($argument->getValue())) {
+                            $argumentValue = (int)$this->output->askConfirmation(
                                 sprintf(
                                     '<comment>%s (%s):</comment> ',
                                     $argumentDefinition->getDescription(),
-                                    $this->isArgumentRequired($argument) ? 'required' : sprintf('default: "%s"', $argument->getDefaultValue())
-                                )
+                                    $isRequired ? 'required' : ($defaultValue ? 'Y/n' : 'y/N')
+                                ),
+                                $defaultValue
                             );
                         } else {
                             $argumentValue = $this->output->ask(
                                 sprintf(
                                     '<comment>%s (%s):</comment> ',
                                     $argumentDefinition->getDescription(),
-                                    $this->isArgumentRequired($argument) ? 'required' : sprintf('default: "%s"', $argument->getDefaultValue())
+                                    $isRequired ? 'required' : sprintf('default: "%s"', $defaultValue === false ? '0' : $defaultValue)
                                 )
                             );
                         }


### PR DESCRIPTION
When asking the user for a boolean value, we now use the
the Symfony confirmation dialogue, which is easier to use.