### PR TITLE
[BUGFIX] Scan for packages before trying to activate them

### DIFF
--- a/Classes/Install/PackageStatesGenerator.php
+++ b/Classes/Install/PackageStatesGenerator.php
@@ -29,6 +29,7 @@ class PackageStatesGenerator
     public function generate(UncachedPackageManager $packageManager, $activateDefaultExtensions = false)
     {
         $frameworkExtensionsFromConfiguration = $this->getFrameworkExtensionsFromConfiguration();
+        $packageManager->scanAvailablePackages();
         foreach ($packageManager->getAvailablePackages() as $package) {
             if (
                 isset($frameworkExtensionsFromConfiguration[$package->getPackageKey()])


### PR DESCRIPTION
With TYPO3 master the method getAvailablePackages only returns
the active packages, unless we call scanAvailablePackages before.

We now always scan for new packages, just in case the extension list
was updated.

Fixes #297