### PR TITLE
[BUGFIX] Use correct statement type for table prefixing

### DIFF
--- a/Classes/Service/Database/SchemaService.php
+++ b/Classes/Service/Database/SchemaService.php
@@ -57,7 +57,7 @@ class SchemaService implements SingletonInterface
         SchemaUpdateType::TABLE_ADD => array('create_table' => self::STATEMENT_GROUP_SAFE),
         SchemaUpdateType::TABLE_CHANGE => array('change_table' => self::STATEMENT_GROUP_SAFE),
         SchemaUpdateType::TABLE_CLEAR => array('clear_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
-        SchemaUpdateType::TABLE_PREFIX => array('change' => self::STATEMENT_GROUP_DESTRUCTIVE),
+        SchemaUpdateType::TABLE_PREFIX => array('change_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
         SchemaUpdateType::TABLE_DROP => array('drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
     );
 


### PR DESCRIPTION
Table prefixing on DB schema update are stored in the "change_table"
section.