### PR TITLE
[BUGFIX] Fix TYPO3 dependency in composer.json and ext_emconf.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,15 @@ matrix:
     - php: 7.0
       env: TYPO3_VERSION=^8
     - php: 7.0
-      env: TYPO3_VERSION=dev-master
+      env: TYPO3_VERSION="dev-master as 8.3.1"
     - php: 7.1
       env: TYPO3_VERSION=^7.6
     - php: 7.1
       env: TYPO3_VERSION=^8
     - php: 7.1
-      env: TYPO3_VERSION=dev-master
+      env: TYPO3_VERSION="dev-master as 8.3.1"
   allow_failures:
-    - env: TYPO3_VERSION=dev-master
+    - env: TYPO3_VERSION="dev-master as 8.3.1"
 
 cache:
   directories:
@@ -56,7 +56,7 @@ before_script:
     fi
   - composer extension-create-libs && ls -la Libraries/*.phar | grep -v ^-rwx
   - git clean -dffx
-  - composer require typo3/cms=$TYPO3_VERSION
+  - composer require typo3/cms="$TYPO3_VERSION"
   - export TYPO3_PATH_WEB="$PWD/.Build/Web"
   - ln -s Scripts/typo3cms typo3cms
 

--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
   array(
     'depends' =>
     array(
-      'typo3' => '7.6.0-8.2.99',
+      'typo3' => '7.6.0-8.3.99',
     ),
     'conflicts' =>
     array(

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
         "php": ">=5.5.0",
         "helhum/typo3-console-plugin": "^1.5.0",
 
-        "typo3/cms-backend": "^7.6 || ^8.0",
-        "typo3/cms-core": "^7.6 || ^8.0",
-        "typo3/cms-extbase": "^7.6 || ^8.0",
-        "typo3/cms-extensionmanager": "^7.6 || ^8.0",
-        "typo3/cms-fluid": "^7.6 || ^8.0",
-        "typo3/cms-install": "^7.6 || ^8.0",
-        "typo3/cms-saltedpasswords": "^7.6 || ^8.0",
-        "typo3/cms-scheduler": "^7.6 || ^8.0",
+        "typo3/cms-backend": "^7.6 || ~8.3.0",
+        "typo3/cms-core": "^7.6 || ~8.3.0",
+        "typo3/cms-extbase": "^7.6 || ~8.3.0",
+        "typo3/cms-extensionmanager": "^7.6 || ~8.3.0",
+        "typo3/cms-fluid": "^7.6 || ~8.3.0",
+        "typo3/cms-install": "^7.6 || ~8.3.0",
+        "typo3/cms-saltedpasswords": "^7.6 || ~8.3.0",
+        "typo3/cms-scheduler": "^7.6 || ~8.3.0",
 
         "symfony/console": "^2.7 || ^3.0",
         "symfony/process": "^2.7 || ^3.0"


### PR DESCRIPTION
Allow installation with EM and TYPO3 8.3.x, disallow installation
with composer and > 8.3.x

Since TYPO3 does not follow semantic versioning, we must ensure that
we do not declare compatibility with a TYPO3 version, that is not released yet.

Although we cannot fix dependencies of the past, this will not affect users,
once we release a version officially compatible with TYPO3 8.4.x