### PR TITLE
[BUGFIX] Fix extension dummy installation

### DIFF
--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -81,7 +81,7 @@ class InstallerScripts
             ];
             foreach ($resources as $resource) {
                 $target = "$extensionDir/$resource";
-                $filesystem->ensureDirectoryExists(basename($target));
+                $filesystem->ensureDirectoryExists(dirname($target));
                 $filesystem->copy("$extResourcesDir/$resource", $target);
             }
             $io->writeError('<info>TYPO3 Console: Installed TYPO3 extension into TYPO3 extension directory</info>');


### PR DESCRIPTION
Ensure the base path of the dummy extension resources exists, not the files as directories.

Fixes #325