### PR TITLE
[BUGFIX] Call data handler API when flushing caches

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -45,6 +45,8 @@ class CacheCommandController extends CommandController
 
         // Flush a second time to have extension caches and previously disabled core caches cleared when clearing not forced
         $this->cacheService->flush();
+        // Also call the data handler API to cover legacy hook subscriber code
+        $this->cacheService->flushCachesWithDataHandler();
 
         $this->outputLine(sprintf('%slushed all caches.', $force ? 'Force f' : 'F'));
     }

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -160,7 +160,7 @@ class CacheService implements SingletonInterface
         $tables = $this->databaseConnection->admin_get_tables();
         foreach ($tables as $table) {
             $tableName = $table['Name'];
-            if (substr($tableName, 0, 3) === 'cf_' || ($tableName !== 'tx_realurl_redirects' && substr($tableName, 0, 11) === 'tx_realurl_')) {
+            if (strpos($tableName, 'cf_') === 0) {
                 $this->databaseConnection->exec_TRUNCATEquery($tableName);
             }
         }

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -13,32 +13,25 @@ namespace Helhum\Typo3Console\Service;
  *
  */
 
+use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheGroupException;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * Class CacheService
- * TODO: This is not really a service in DDD terms: it does not act on domain models, it has dependencies and it holds som kind of state (logger) find a better name/pattern for that.
+ * Cache Service handles all cache clearing related tasks
  */
 class CacheService implements SingletonInterface
 {
     /**
-     * @var \TYPO3\CMS\Core\Cache\CacheManager
-     * @inject
+     * @var CacheManager
      */
     protected $cacheManager;
 
     /**
-     * @var \TYPO3\CMS\Core\Package\PackageManager
-     * @inject
-     */
-    protected $packageManager;
-
-    /**
-     * @var \Helhum\Typo3Console\Service\Configuration\ConfigurationService
-     * @inject
+     * @var ConfigurationService
      */
     protected $configurationService;
 
@@ -50,10 +43,17 @@ class CacheService implements SingletonInterface
     /**
      * Builds the dependencies correctly
      *
+     * @param CacheManager $cacheManager
+     * @param ConfigurationService $configurationService
      * @param DatabaseConnection $databaseConnection
      */
-    public function __construct(DatabaseConnection $databaseConnection = null)
+    public function __construct(
+        CacheManager $cacheManager,
+        ConfigurationService $configurationService,
+        DatabaseConnection $databaseConnection = null)
     {
+        $this->cacheManager = $cacheManager;
+        $this->configurationService = $configurationService;
         $this->databaseConnection = $databaseConnection ?: $GLOBALS['TYPO3_DB'];
     }
 

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -14,9 +14,11 @@ namespace Helhum\Typo3Console\Service;
  */
 
 use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheGroupException;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -68,6 +70,31 @@ class CacheService implements SingletonInterface
             $this->forceFlushCoreFileAndDatabaseCaches();
         }
         $this->cacheManager->flushCaches();
+    }
+
+    /**
+     * Flushes caches using the data handler. This should not be necessary any more in the future.
+     * Although we trigger the cache flush API here, the real intention is to trigger
+     * hook subscribers, so that they can do their job (flushing "other" caches when cache is flushed.
+     * For example realurl subscribes to these hooks.
+     *
+     * We use "all" because this method is only called from "flush" command which is indeed meant
+     * to flush all caches. Besides that, "all" is really all caches starting from TYPO3 8.x
+     * thus it would make sense for the hook subscribers to act on that cache clear type.
+     *
+     * However if you find a valid use case for us to also call "pages" here, then please create
+     * a pull request and describe this case. "system" or "temp_cached" will not be added however
+     * because these are deprecated since TYPO3 8.x
+     *
+     * Besides that, this DataHandler API is probably something to be removed in TYPO3,
+     * so we deprecate and mark this method as internal at the same time.
+     *
+     * @deprecated
+     * @internal
+     */
+    public function flushCachesWithDataHandler()
+    {
+        self::createDataHandlerFromGlobals()->clear_cacheCmd('all');
     }
 
     /**
@@ -164,5 +191,22 @@ class CacheService implements SingletonInterface
                 $this->databaseConnection->exec_TRUNCATEquery($tableName);
             }
         }
+    }
+
+    /**
+     * Create a data handler instance from global state (with user being admin)
+     * @internal
+     * @return DataHandler
+     */
+    private static function createDataHandlerFromGlobals()
+    {
+        if (empty($GLOBALS['BE_USER']) || !$GLOBALS['BE_USER'] instanceof BackendUserAuthentication) {
+            throw new \RuntimeException('No backend user initialized. flushCachesWithDataHandler needs fully initialized TYPO3', 1477066610);
+        }
+        $user = clone $GLOBALS['BE_USER'];
+        $user->admin = 1;
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], [], $user);
+        return $dataHandler;
     }
 }

--- a/Tests/Unit/Service/CacheServiceTest.php
+++ b/Tests/Unit/Service/CacheServiceTest.php
@@ -13,7 +13,9 @@ namespace Helhum\Typo3Console\Tests\Unit\Service;
  *
  */
 
+use Helhum\Typo3Console\Service\CacheService;
 use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Tests\UnitTestCase;
 
 /**
@@ -28,7 +30,9 @@ class CacheServiceTest extends UnitTestCase
 
     public function setup()
     {
-        $this->subject = $this->getAccessibleMock(\Helhum\Typo3Console\Service\CacheService::class, array('getLogger'));
+        $cacheManagerMock = $this->getMockBuilder(CacheManager::class)->disableOriginalConstructor()->getMock();
+        $configurationServiceMock = $this->getMockBuilder(ConfigurationService::class)->disableOriginalConstructor()->getMock();
+        $this->subject = new CacheService($cacheManagerMock, $configurationServiceMock);
     }
 
     /**
@@ -43,7 +47,7 @@ class CacheServiceTest extends UnitTestCase
             ->expects($this->atLeastOnce())
             ->method('getActive')
             ->will($this->returnValue($mockedConfiguration));
-        $this->subject->_set('configurationService', $configurationServiceMock);
+        $this->inject($this->subject, 'configurationService', $configurationServiceMock);
     }
 
     /**


### PR DESCRIPTION
Because of the removal of the realurl cache table clearing workaround,
we must now take care to call the data handler API, so that realurl
hooks subscribers that clear the caches are called.

All other cache hook subscribers are thus called as well.

Nevertheless we consider this legacy API and mark the according methods
as deprecated and internal at the same time.
Nothing will be exposed to userland.

Fixes #286