### PR TITLE
[!!!][FEATURE] Auto-create _cli_lowlevel user

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -233,7 +233,6 @@ class ConsoleBootstrap extends Bootstrap
         define('TYPO3_MODE', 'BE');
         // @deprecated to define this constant. Can be removed when TYPO3 7 support is removed
         define('TYPO3_cliMode', true);
-        $GLOBALS['MCONF']['name'] = '_CLI_lowlevel';
         parent::baseSetup($pathPart);
         // I want to see deprecation messages
         error_reporting(E_ALL & ~(E_STRICT | E_NOTICE));

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -15,7 +15,6 @@ namespace Helhum\Typo3Console\Install;
 
 use Helhum\Typo3Console\Install\Status\RedirectStatus;
 use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
-use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Cli\CommandArgumentDefinition;
 use TYPO3\CMS\Extbase\Mvc\Controller\Argument;
@@ -122,14 +121,7 @@ class CliSetupRequestHandler
      */
     public function executeActionWithArguments($actionName, array $arguments = [])
     {
-        // TODO: provide pre- and post-execute signals?
         $messages = $this->executeAction($this->createActionWithNameAndArguments($actionName, $arguments));
-        // TODO: ultimately get rid of that!
-        if ($messages === [] && $actionName === 'databaseData') {
-            /** @var DatabaseConnection $db */
-            $db = $GLOBALS['TYPO3_DB'];
-            $db->exec_INSERTquery('be_users', ['username' => '_cli_lowlevel']);
-        }
         $this->output->outputLine(serialize($messages));
     }
 


### PR DESCRIPTION
Instead of creating the (unfortunately still required) cli user
during installation, we now create it during runtime,
if it does not exist.

This has the benefit, that we have this code in one place
and have it simplified.

This comes with a little downside, that if a disabled user already
exists, that it cannot be created any more. We accept this as the
likeliness that this happens is rather low.

This change is only slightly breaking because we at the same
time removed the MCONF name global.