### PR TITLE
Do not prefix fields/tables on "*.change" DB schema update

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -52,10 +52,12 @@ class DatabaseCommandController extends CommandController {
 	protected $schemaUpdateTypeLabels = array(
 		SchemaUpdateType::FIELD_ADD => 'Add fields',
 		SchemaUpdateType::FIELD_CHANGE => 'Change fields',
+		SchemaUpdateType::FIELD_PREFIX => 'Prefix fields',
 		SchemaUpdateType::FIELD_DROP => 'Drop fields',
 		SchemaUpdateType::TABLE_ADD => 'Add tables',
 		SchemaUpdateType::TABLE_CHANGE => 'Change tables',
 		SchemaUpdateType::TABLE_CLEAR => 'Clear tables',
+		SchemaUpdateType::TABLE_PREFIX => 'Prefix tables',
 		SchemaUpdateType::TABLE_DROP => 'Drop tables',
 	);
 

--- a/Classes/Service/Database/Schema/SchemaService.php
+++ b/Classes/Service/Database/Schema/SchemaService.php
@@ -36,6 +36,16 @@ use TYPO3\CMS\Core\Utility\ArrayUtility;
 class SchemaService implements SingletonInterface {
 
 	/**
+	 * Group of safe statements
+	 */
+	const STATEMENT_GROUP_SAFE = 'add_create_change';
+
+	/**
+	 * Group of destructive statements
+	 */
+	const STATEMENT_GROUP_DESTRUCTIVE = 'drop_rename';
+
+	/**
 	 * @var \TYPO3\CMS\Install\Service\SqlSchemaMigrationService
 	 * @inject
 	 */
@@ -53,13 +63,15 @@ class SchemaService implements SingletonInterface {
 	 * @var array
 	 */
 	protected $schemaUpdateTypesStatementTypesMapping = array(
-		SchemaUpdateType::FIELD_ADD => array('add'),
-		SchemaUpdateType::FIELD_CHANGE => array('change'),
-		SchemaUpdateType::FIELD_DROP => array('drop'),
-		SchemaUpdateType::TABLE_ADD => array('create_table'),
-		SchemaUpdateType::TABLE_CHANGE => array('change_table'),
-		SchemaUpdateType::TABLE_CLEAR => array('clear_table'),
-		SchemaUpdateType::TABLE_DROP => array('drop_table'),
+		SchemaUpdateType::FIELD_ADD => array('add' => self::STATEMENT_GROUP_SAFE),
+		SchemaUpdateType::FIELD_CHANGE => array('change' => self::STATEMENT_GROUP_SAFE),
+		SchemaUpdateType::FIELD_PREFIX => array('change' => self::STATEMENT_GROUP_DESTRUCTIVE),
+		SchemaUpdateType::FIELD_DROP => array('drop' => self::STATEMENT_GROUP_DESTRUCTIVE),
+		SchemaUpdateType::TABLE_ADD => array('create_table' => self::STATEMENT_GROUP_SAFE),
+		SchemaUpdateType::TABLE_CHANGE => array('change_table' => self::STATEMENT_GROUP_SAFE),
+		SchemaUpdateType::TABLE_CLEAR => array('clear_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
+		SchemaUpdateType::TABLE_PREFIX => array('change_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
+		SchemaUpdateType::TABLE_DROP => array('drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
 	);
 
 	/**
@@ -75,18 +87,19 @@ class SchemaService implements SingletonInterface {
 		$addCreateChange = $this->schemaMigrationService->getDatabaseExtra($expectedSchema, $currentSchema);
 		$dropRename = $this->schemaMigrationService->getDatabaseExtra($currentSchema, $expectedSchema);
 
-		$updateStatements = array();
-		ArrayUtility::mergeRecursiveWithOverrule($updateStatements, $this->schemaMigrationService->getUpdateSuggestions($addCreateChange));
-		ArrayUtility::mergeRecursiveWithOverrule($updateStatements, $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove'));
+		$updateStatements = array(
+			self::STATEMENT_GROUP_SAFE => $this->schemaMigrationService->getUpdateSuggestions($addCreateChange),
+			self::STATEMENT_GROUP_DESTRUCTIVE => $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove'),
+		);
 
 		$updateResult = new SchemaUpdateResult();
 
 		foreach ($schemaUpdateTypes as $schemaUpdateType) {
 			$statementTypes = $this->getStatementTypes($schemaUpdateType);
 
-			foreach ($statementTypes as $statementType) {
-				if (isset($updateStatements[$statementType])) {
-					$statements = $updateStatements[$statementType];
+			foreach ($statementTypes as $statementType => $statementGroup) {
+				if (isset($updateStatements[$statementGroup][$statementType])) {
+					$statements = $updateStatements[$statementGroup][$statementType];
 					$result = $this->schemaMigrationService->performUpdateQueries(
 						$statements,
 						// Generate a map of statements as keys and TRUE as values

--- a/Classes/Service/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Service/Database/Schema/SchemaUpdateType.php
@@ -50,6 +50,11 @@ class SchemaUpdateType extends Enumeration {
 	const FIELD_CHANGE = 'field.change';
 
 	/**
+	 * Prefix a field
+	 */
+	const FIELD_PREFIX = 'field.prefix';
+
+	/**
 	 * Drop a field
 	 */
 	const FIELD_DROP = 'field.drop';
@@ -63,6 +68,11 @@ class SchemaUpdateType extends Enumeration {
 	 * Change a table
 	 */
 	const TABLE_CHANGE = 'table.change';
+
+	/**
+	 * Prefix a table
+	 */
+	const TABLE_PREFIX = 'table.prefix';
 
 	/**
 	 * Drop a table


### PR DESCRIPTION
The prefixing of fields and tables is a basically destructive schema
update, thus it is not really expected when "*.change" updates are
requested.

Fix this by splitting update suggestions into safe and destructive
statements and introducing the "field.prefix" and "table.prefix"
schema update types.

This is mildly breaking if you expect field/table prefixing upon
"*.change" but it actually ensures that your data is left untouched
unless requested otherwise.

Fixes #301