### PR TITLE
[BUGFIX] Allow setting configuration even if not active

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,8 @@ script:
   - ./typo3cms configuration:set BE/installToolPassword foobar && grep installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep foobar
   - ./typo3cms configuration:remove BE/installToolPassword --force && grep -qv installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
   - ./typo3cms configuration:set BE/installToolPassword blablupp && grep installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep blablupp
+  - ./typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
+  - ./typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep baz
   - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && ./typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
   - rm $TYPO3_PATH_WEB/typo3temp/index.html && ./typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_WEB/typo3temp/index.html" ]
   - ./typo3cms extension:list

--- a/Classes/Service/Configuration/TypesAreNotConvertibleException.php
+++ b/Classes/Service/Configuration/TypesAreNotConvertibleException.php
@@ -1,0 +1,21 @@
+<?php
+namespace Helhum\Typo3Console\Service\Configuration;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/**
+ * Variable types could not be converted
+ */
+class TypesAreNotConvertibleException extends \Exception
+{
+}


### PR DESCRIPTION
configuration:set did not change a configuration value
if it has been modified compared to the local configuration value.
However sometimes it is important to nevertheless write the
value to LocalConfiguration.php

Therefore we remove this restriction and only issue a warning
in this case.