### PR TITLE
[BUGFIX] Use correct group for table_clear statements

### DIFF
--- a/Classes/Service/Database/SchemaService.php
+++ b/Classes/Service/Database/SchemaService.php
@@ -56,7 +56,7 @@ class SchemaService implements SingletonInterface
         SchemaUpdateType::FIELD_DROP => ['drop' => self::STATEMENT_GROUP_DESTRUCTIVE],
         SchemaUpdateType::TABLE_ADD => ['create_table' => self::STATEMENT_GROUP_SAFE],
         SchemaUpdateType::TABLE_CHANGE => ['change_table' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::TABLE_CLEAR => ['clear_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
+        SchemaUpdateType::TABLE_CLEAR => ['clear_table' => self::STATEMENT_GROUP_SAFE],
         SchemaUpdateType::TABLE_PREFIX => ['change_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
         SchemaUpdateType::TABLE_DROP => ['drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
     ];


### PR DESCRIPTION
TYPO3 considers table_clear statements to be part of
add/create/change workflow and therefore considered safe.

We must move it there so that the statements are executed