### PR TITLE
[BUGFIX] Use correct group for table_clear statements

### DIFF
--- a/Classes/Service/Database/Schema/SchemaService.php
+++ b/Classes/Service/Database/Schema/SchemaService.php
@@ -69,7 +69,7 @@ class SchemaService implements SingletonInterface {
 		SchemaUpdateType::FIELD_DROP => array('drop' => self::STATEMENT_GROUP_DESTRUCTIVE),
 		SchemaUpdateType::TABLE_ADD => array('create_table' => self::STATEMENT_GROUP_SAFE),
 		SchemaUpdateType::TABLE_CHANGE => array('change_table' => self::STATEMENT_GROUP_SAFE),
-		SchemaUpdateType::TABLE_CLEAR => array('clear_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
+		SchemaUpdateType::TABLE_CLEAR => array('clear_table' => self::STATEMENT_GROUP_SAFE),
 		SchemaUpdateType::TABLE_PREFIX => array('change_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
 		SchemaUpdateType::TABLE_DROP => array('drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
 	);


### PR DESCRIPTION
TYPO3 considers table_clear statements to be part of
add/create/change workflow and therefore considered safe.

We must move it there so that the statements are executed