### PR TITLE
[!!!][FEATURE] Add "safe" and "destructive" to database:updateschema

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -57,6 +57,8 @@ class DatabaseCommandController extends CommandController
      * - table.prefix
      * - table.drop
      * - table.clear
+     * - safe (includes all necessary operations, to add or change fields or tables)
+     * - destructive (includes all operations which rename or drop fields or tables)
      *
      * The list of schema update types supports wildcards to specify multiple types, e.g.:
      *

--- a/Classes/Database/Schema/SchemaUpdateResultRenderer.php
+++ b/Classes/Database/Schema/SchemaUpdateResultRenderer.php
@@ -24,7 +24,7 @@ class SchemaUpdateResultRenderer
      *
      * @var array
      */
-    protected $schemaUpdateTypeLabels = [
+    private static $schemaUpdateTypeLabels = [
         SchemaUpdateType::FIELD_ADD => 'Add fields',
         SchemaUpdateType::FIELD_CHANGE => 'Change fields',
         SchemaUpdateType::FIELD_PREFIX => 'Prefix fields',
@@ -49,9 +49,9 @@ class SchemaUpdateResultRenderer
         $tableRows = [];
 
         foreach ($result->getPerformedUpdates() as $type => $performedUpdates) {
-            $row = [$this->schemaUpdateTypeLabels[(string)$type], count($performedUpdates)];
+            $row = [self::$schemaUpdateTypeLabels[(string)$type], count($performedUpdates)];
             if ($includeStatements) {
-                $row = [$this->schemaUpdateTypeLabels[(string)$type], implode(chr(10) . chr(10), $this->getTruncatedQueries($performedUpdates, $maxStatementLength))];
+                $row = [self::$schemaUpdateTypeLabels[(string)$type], implode(chr(10) . chr(10), $this->getTruncatedQueries($performedUpdates, $maxStatementLength))];
             }
             $tableRows[] = $row;
         }
@@ -63,7 +63,7 @@ class SchemaUpdateResultRenderer
 
         if ($result->hasErrors()) {
             foreach ($result->getErrors() as $type => $errors) {
-                $output->outputLine(sprintf('<error>Errors during "%s" schema update:</error>', $this->schemaUpdateTypeLabels[(string)$type]));
+                $output->outputLine(sprintf('<error>Errors during "%s" schema update:</error>', self::$schemaUpdateTypeLabels[(string)$type]));
 
                 foreach ($errors as $error) {
                     $output->outputFormatted('<error>' . $error . '</error>', [], 2);

--- a/Classes/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Database/Schema/SchemaUpdateType.php
@@ -22,11 +22,6 @@ use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
 class SchemaUpdateType extends Enumeration
 {
     /**
-     * @var int
-     */
-    protected $value;
-
-    /**
      * Add a field
      */
     const FIELD_ADD = 'field.add';
@@ -72,6 +67,57 @@ class SchemaUpdateType extends Enumeration
     const TABLE_CLEAR = 'table.clear';
 
     /**
+     * All safe update types
+     */
+    const GROUP_SAFE = 'safe';
+
+    /**
+     * All destructive update types
+     */
+    const GROUP_DESTRUCTIVE = 'destructive';
+
+    /**
+     * Mapping of schema update types to internal statement types
+     *
+     * @var array
+     */
+    private static $schemaUpdateTypesStatementTypesMapping = [
+        self::FIELD_ADD => ['add' => self::GROUP_SAFE],
+        self::FIELD_CHANGE => ['change' => self::GROUP_SAFE],
+        self::FIELD_PREFIX => ['change' => self::GROUP_DESTRUCTIVE],
+        self::FIELD_DROP => ['drop' => self::GROUP_DESTRUCTIVE],
+        self::TABLE_ADD => ['create_table' => self::GROUP_SAFE],
+        self::TABLE_CHANGE => ['change_table' => self::GROUP_SAFE],
+        self::TABLE_CLEAR => ['clear_table' => self::GROUP_SAFE],
+        self::TABLE_PREFIX => ['change_table' => self::GROUP_DESTRUCTIVE],
+        self::TABLE_DROP => ['drop_table' => self::GROUP_DESTRUCTIVE],
+        self::GROUP_SAFE => [
+            self::FIELD_ADD,
+            self::FIELD_CHANGE,
+            self::TABLE_ADD,
+            self::TABLE_CHANGE,
+            self::TABLE_CLEAR,
+        ],
+        self::GROUP_DESTRUCTIVE => [
+            self::FIELD_PREFIX,
+            self::FIELD_DROP,
+            self::TABLE_PREFIX,
+            self::TABLE_DROP,
+        ],
+        '*' => [
+            self::FIELD_ADD,
+            self::FIELD_CHANGE,
+            self::FIELD_PREFIX,
+            self::FIELD_DROP,
+            self::TABLE_ADD,
+            self::TABLE_CHANGE,
+            self::TABLE_PREFIX,
+            self::TABLE_DROP,
+            self::TABLE_CLEAR,
+        ],
+    ];
+
+    /**
      * Expands wildcards in schema update types, e.g. field.* or *.change
      *
      * @param array $schemaUpdateTypes List of schema update types
@@ -85,10 +131,37 @@ class SchemaUpdateType extends Enumeration
 
         // Collect total list of types by expanding wildcards
         foreach ($schemaUpdateTypes as $schemaUpdateType) {
-            if (strpos($schemaUpdateType, '*') !== false) {
+            if (in_array($schemaUpdateType, ['*', 'safe', 'destructive'], true)) {
+                if (empty(self::$schemaUpdateTypesStatementTypesMapping[$schemaUpdateType])) {
+                    throw new InvalidEnumerationValueException(
+                        sprintf(
+                            'Invalid schema update type "%s", must be one of: "%s"',
+                            $schemaUpdateType,
+                            implode('", "', $schemaUpdateTypeConstants)
+                        ),
+                        1477998197
+                    );
+                } else {
+                    foreach (self::$schemaUpdateTypesStatementTypesMapping[$schemaUpdateType] as $matchedType) {
+                        $expandedSchemaUpdateTypes[] = $matchedType;
+                    }
+                }
+            } elseif (strpos($schemaUpdateType, '*') !== false) {
                 $matchPattern = '/' . str_replace('\\*', '.+', preg_quote($schemaUpdateType, '/')) . '/';
                 $matchingSchemaUpdateTypes = preg_grep($matchPattern, $schemaUpdateTypeConstants);
-                $expandedSchemaUpdateTypes = array_merge($expandedSchemaUpdateTypes, $matchingSchemaUpdateTypes);
+                if (empty($matchingSchemaUpdateTypes)) {
+                    throw new InvalidEnumerationValueException(
+                        sprintf(
+                            'Invalid schema update type "%s", must be one of: "%s"',
+                            $schemaUpdateType,
+                            implode('", "', $schemaUpdateTypeConstants)
+                        ),
+                        1477998245
+                    );
+                }
+                foreach ($matchingSchemaUpdateTypes as $matchingSchemaUpdateType) {
+                    $expandedSchemaUpdateTypes[] = $matchingSchemaUpdateType;
+                }
             } else {
                 $expandedSchemaUpdateTypes[] = $schemaUpdateType;
             }
@@ -99,13 +172,28 @@ class SchemaUpdateType extends Enumeration
             try {
                 $schemaUpdateType = self::cast($schemaUpdateType);
             } catch (InvalidEnumerationValueException $e) {
-                throw new InvalidEnumerationValueException(sprintf(
-                    'Invalid schema update type "%s", must be one of: "%s"',
-                    $schemaUpdateType,
-                    implode('", "', $schemaUpdateTypeConstants)
-                ), 1439460396);
+                throw new InvalidEnumerationValueException(
+                    sprintf(
+                        'Invalid schema update type "%s", must be one of: "%s"',
+                        $schemaUpdateType,
+                        implode('", "', $schemaUpdateTypeConstants)
+                    ),
+                    1439460396,
+                    $e
+                );
             }
         }
+
         return $expandedSchemaUpdateTypes;
+    }
+
+    /**
+     * Map schema update type to a list of internal statement types
+     *
+     * @return array
+     */
+    public function getStatementTypes()
+    {
+        return self::$schemaUpdateTypesStatementTypesMapping[(string)$this];
     }
 }

--- a/Classes/Service/Database/SchemaService.php
+++ b/Classes/Service/Database/SchemaService.php
@@ -22,15 +22,6 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 class SchemaService implements SingletonInterface
 {
-    /**
-     * Group of safe statements
-     */
-    const STATEMENT_GROUP_SAFE = 'add_create_change';
-
-    /**
-     * Group of destructive statements
-     */
-    const STATEMENT_GROUP_DESTRUCTIVE = 'drop_rename';
 
     /**
      * @var \TYPO3\CMS\Install\Service\SqlSchemaMigrationService
@@ -43,23 +34,6 @@ class SchemaService implements SingletonInterface
      * @inject
      */
     protected $expectedSchemaService;
-
-    /**
-     * Mapping of schema update types to internal statement types
-     *
-     * @var array
-     */
-    protected $schemaUpdateTypesStatementTypesMapping = [
-        SchemaUpdateType::FIELD_ADD => ['add' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::FIELD_CHANGE => ['change' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::FIELD_PREFIX => ['change' => self::STATEMENT_GROUP_DESTRUCTIVE],
-        SchemaUpdateType::FIELD_DROP => ['drop' => self::STATEMENT_GROUP_DESTRUCTIVE],
-        SchemaUpdateType::TABLE_ADD => ['create_table' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::TABLE_CHANGE => ['change_table' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::TABLE_CLEAR => ['clear_table' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::TABLE_PREFIX => ['change_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
-        SchemaUpdateType::TABLE_DROP => ['drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
-    ];
 
     /**
      * Perform necessary database schema migrations
@@ -76,16 +50,14 @@ class SchemaService implements SingletonInterface
         $dropRename = $this->schemaMigrationService->getDatabaseExtra($currentSchema, $expectedSchema);
 
         $updateStatements = [
-            self::STATEMENT_GROUP_SAFE => $this->schemaMigrationService->getUpdateSuggestions($addCreateChange),
-            self::STATEMENT_GROUP_DESTRUCTIVE => $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove'),
+            SchemaUpdateType::GROUP_SAFE => $this->schemaMigrationService->getUpdateSuggestions($addCreateChange),
+            SchemaUpdateType::GROUP_DESTRUCTIVE => $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove'),
         ];
 
         $updateResult = new SchemaUpdateResult();
 
         foreach ($schemaUpdateTypes as $schemaUpdateType) {
-            $statementTypes = $this->getStatementTypes($schemaUpdateType);
-
-            foreach ($statementTypes as $statementType => $statementGroup) {
+            foreach ($schemaUpdateType->getStatementTypes() as $statementType => $statementGroup) {
                 if (isset($updateStatements[$statementGroup][$statementType])) {
                     $statements = $updateStatements[$statementGroup][$statementType];
                     $result = $this->schemaMigrationService->performUpdateQueries(
@@ -104,16 +76,5 @@ class SchemaService implements SingletonInterface
         }
 
         return $updateResult;
-    }
-
-    /**
-     * Map schema update type to a list of internal statement types
-     *
-     * @param SchemaUpdateType $schemaUpdateType Schema update types
-     * @return array
-     */
-    protected function getStatementTypes(SchemaUpdateType $schemaUpdateType)
-    {
-        return $this->schemaUpdateTypesStatementTypesMapping[(string)$schemaUpdateType];
     }
 }

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2016-10-17 12:08:09
+The following reference was automatically generated from code on 2016-11-01 12:48:56
 
 
 .. _`Command Reference: typo3_console`:
@@ -474,6 +474,8 @@ Valid schema update types are:
 - table.prefix
 - table.drop
 - table.clear
+- safe (includes all necessary operations, to add or change fields or tables)
+- destructive (includes all operations which rename or drop fields or tables)
 
 The list of schema update types supports wildcards to specify multiple types, e.g.:
 

--- a/Tests/Unit/Database/Schema/SchemaUpdateTypeTest.php
+++ b/Tests/Unit/Database/Schema/SchemaUpdateTypeTest.php
@@ -1,0 +1,152 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Database\Schema;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Database\Schema\SchemaUpdateType;
+use TYPO3\CMS\Core\Tests\UnitTestCase;
+
+/**
+ * Class SchemaUpdateTypeTest
+ */
+class SchemaUpdateTypeTest extends UnitTestCase
+{
+    /**
+     * @return array
+     */
+    public function expandTypesExpandsCorrectlyDataProvider()
+    {
+        return [
+            'all' => [
+                '*',
+                [
+                    'field.add',
+                    'field.change',
+                    'field.prefix',
+                    'field.drop',
+                    'table.add',
+                    'table.change',
+                    'table.prefix',
+                    'table.drop',
+                    'table.clear',
+                ]
+            ],
+            'fields' => [
+                'field.*',
+                [
+                    'field.add',
+                    'field.change',
+                    'field.prefix',
+                    'field.drop',
+                ]
+            ],
+            'tables' => [
+                'table.*',
+                [
+                    'table.add',
+                    'table.change',
+                    'table.prefix',
+                    'table.drop',
+                    'table.clear',
+                ]
+            ],
+            'all add' => [
+                '*.add',
+                [
+                    'field.add',
+                    'table.add',
+                ]
+            ],
+            'all change' => [
+                '*.change',
+                [
+                    'field.change',
+                    'table.change',
+                ]
+            ],
+            'all prefix' => [
+                '*.prefix',
+                [
+                    'field.prefix',
+                    'table.prefix',
+                ]
+            ],
+            'all drop' => [
+                '*.drop',
+                [
+                    'field.drop',
+                    'table.drop',
+                ]
+            ],
+            'all clear' => [
+                '*.clear',
+                [
+                    'table.clear',
+                ]
+            ],
+            'all safe' => [
+                'safe',
+                [
+                    'field.add',
+                    'field.change',
+                    'table.add',
+                    'table.change',
+                    'table.clear',
+                ]
+            ],
+            'all destructive' => [
+                'destructive',
+                [
+                    'field.prefix',
+                    'field.drop',
+                    'table.prefix',
+                    'table.drop',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider expandTypesExpandsCorrectlyDataProvider
+     * @param string $expandable
+     * @param string[] $expected
+     */
+    public function expandTypesExpandsCorrectly($expandable, array $expected)
+    {
+        $updateTypes = array_map('strval', SchemaUpdateType::expandSchemaUpdateTypes([$expandable]));
+        $this->assertSame($expected, $updateTypes);
+    }
+    /**
+     * @return array
+     */
+    public function expandTypesFailsForInvalidTypesDataProvider()
+    {
+        return [
+            'not known' => ['sadasd'],
+            'not known with * at end' => ['sadasd.*'],
+            'not known with * at beginning' => ['*.sadasd'],
+            'all.*' => ['all.*'],
+        ];
+    }
+    /**
+     * @test
+     * @dataProvider expandTypesFailsForInvalidTypesDataProvider
+     * @param string $expandable
+     * @expectedException \TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException
+     */
+    public function expandTypesFailsForInvalidTypes($expandable)
+    {
+        SchemaUpdateType::expandSchemaUpdateTypes([$expandable]);
+    }
+}


### PR DESCRIPTION
Refactor the schema types to be also responsible for the
mapping to the statement types.

This has the little downside that this class now has a
dependency to internal array structure of TYPO3 schema updates,
however it is natural from a users perspective to have the
new types in this enum as well.

We now also added tests for this class and fixed some
issues found due to these tests.

Also add new documentation to explain the new possibilities.