### PR TITLE
[FEATURE] Make update types optional

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -70,10 +70,10 @@ class DatabaseCommandController extends CommandController
      *
      * <b>Example:</b> <code>./typo3cms database:updateschema "*.add,*.change"</code>
      *
-     * @param array $schemaUpdateTypes List of schema update types
+     * @param array $schemaUpdateTypes List of schema update types (default: "safe")
      * @param bool $verbose If set, database queries performed are shown in output
      */
-    public function updateSchemaCommand(array $schemaUpdateTypes, $verbose = false)
+    public function updateSchemaCommand(array $schemaUpdateTypes = ['safe'], $verbose = false)
     {
         try {
             $schemaUpdateTypes = SchemaUpdateType::expandSchemaUpdateTypes($schemaUpdateTypes);

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2016-11-01 12:48:56
+The following reference was automatically generated from code on 2016-11-01 12:54:22
 
 
 .. _`Command Reference: typo3_console`:
@@ -487,17 +487,13 @@ To avoid shell matching all types with wildcards should be quoted.
 
 **Example:** ``./typo3cms database:updateschema "*.add,*.change"``
 
-Arguments
-^^^^^^^^^
-
-``--schema-update-types``
-  List of schema update types
-
 
 
 Options
 ^^^^^^^
 
+``--schema-update-types``
+  List of schema update types (default: "safe")
 ``--verbose``
   If set, database queries performed are shown in output
 


### PR DESCRIPTION
By default the database:updateschema command should
execute all safe actions