### PR TITLE
[FEATURE] Implement TYPO3 8 specific schema update

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -77,19 +77,24 @@ class DatabaseCommandController extends CommandController
     public function updateSchemaCommand(array $schemaUpdateTypes = ['safe'], $verbose = false, $dryRun = false)
     {
         try {
-            $schemaUpdateTypes = SchemaUpdateType::expandSchemaUpdateTypes($schemaUpdateTypes);
+            $expandedSchemaUpdateTypes = SchemaUpdateType::expandSchemaUpdateTypes($schemaUpdateTypes);
         } catch (InvalidEnumerationValueException $e) {
             $this->outputLine(sprintf('<error>%s</error>', $e->getMessage()));
             $this->sendAndExit(1);
         }
 
-        $result = $this->schemaService->updateSchema($schemaUpdateTypes, $dryRun);
+        $result = $this->schemaService->updateSchema($expandedSchemaUpdateTypes, $dryRun);
 
         if ($result->hasPerformedUpdates()) {
             $this->output->outputLine('<info>The following database schema updates %s performed:</info>', [$dryRun ? 'should be' : 'were']);
             $this->schemaUpdateResultRenderer->render($result, $this->output, $verbose);
         } else {
-            $this->output->outputLine('No schema updates matching the given types were performed');
+            $this->output->outputLine(
+                '<info>No schema updates %s performed for update type%s:%s</info>',
+                [$dryRun ? 'must be' : 'were',
+                count($expandedSchemaUpdateTypes) > 1 ? 's' : '',
+                PHP_EOL . implode(PHP_EOL, $expandedSchemaUpdateTypes)]
+            );
         }
     }
 

--- a/Classes/Database/Schema/LegacySchemaUpdate.php
+++ b/Classes/Database/Schema/LegacySchemaUpdate.php
@@ -1,0 +1,92 @@
+<?php
+namespace Helhum\Typo3Console\Database\Schema;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Install\Service\SqlExpectedSchemaService;
+use TYPO3\CMS\Install\Service\SqlSchemaMigrationService;
+
+/**
+ * The database schema update implementation for TYPO3 7.6
+ * @deprecated since TYPO3 8.x, will be removed when TYPO3 7.6 support will be removed
+ */
+class LegacySchemaUpdate implements SchemaUpdateInterface, SingletonInterface
+{
+    /**
+     * @var SqlSchemaMigrationService
+     */
+    private $schemaMigrationService;
+
+    /**
+     * @var SqlExpectedSchemaService
+     */
+    private $expectedSchemaService;
+
+    /**
+     * SchemaUpdate constructor.
+     *
+     * @param SqlSchemaMigrationService $schemaMigrationService
+     * @param SqlExpectedSchemaService $expectedSchemaService
+     */
+    public function __construct(SqlSchemaMigrationService $schemaMigrationService, SqlExpectedSchemaService $expectedSchemaService)
+    {
+        $this->schemaMigrationService = $schemaMigrationService;
+        $this->expectedSchemaService = $expectedSchemaService;
+    }
+
+    /**
+     * Get all schema updates that are considered (relatively) safe
+     *
+     * @return array
+     */
+    public function getSafeUpdates()
+    {
+        $expectedSchema = $this->expectedSchemaService->getExpectedDatabaseSchema();
+        $currentSchema = $this->schemaMigrationService->getFieldDefinitions_database();
+        $addCreateChange = $this->schemaMigrationService->getDatabaseExtra($expectedSchema, $currentSchema);
+
+        return $this->schemaMigrationService->getUpdateSuggestions($addCreateChange);
+    }
+
+    /**
+     * Get all schema updates that are destructive (renaming/ deleting fields/ tables)
+     *
+     * @return array
+     */
+    public function getDestructiveUpdates()
+    {
+        $expectedSchema = $this->expectedSchemaService->getExpectedDatabaseSchema();
+        $currentSchema = $this->schemaMigrationService->getFieldDefinitions_database();
+        $dropRename = $this->schemaMigrationService->getDatabaseExtra($currentSchema, $expectedSchema);
+
+        return $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove');
+    }
+
+    /**
+     * Actually execute the migration to the new schema
+     *
+     * @param array $statements
+     * @param array $selectedStatements
+     * @return array
+     */
+    public function migrate(array $statements, array $selectedStatements)
+    {
+        $result = $this->schemaMigrationService->performUpdateQueries($statements, $selectedStatements);
+        if ($result === true) {
+            return [];
+        } else {
+            return $result;
+        }
+    }
+}

--- a/Classes/Database/Schema/SchemaUpdate.php
+++ b/Classes/Database/Schema/SchemaUpdate.php
@@ -1,0 +1,88 @@
+<?php
+namespace Helhum\Typo3Console\Database\Schema;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use TYPO3\CMS\Core\Database\Schema\SchemaMigrator;
+use TYPO3\CMS\Core\Database\Schema\SqlReader;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The database schema update implementation for TYPO3 8.x
+ */
+class SchemaUpdate implements SchemaUpdateInterface, SingletonInterface
+{
+    /**
+     * @var SqlReader
+     */
+    private $sqlReader;
+
+    /**
+     * @var SchemaMigrator
+     */
+    private $schemaMigrator;
+
+    /**
+     * SchemaUpdate constructor.
+     *
+     * @param SqlReader $sqlReader
+     * @param SchemaMigrator $schemaMigrator
+     */
+    public function __construct(SqlReader $sqlReader = null, SchemaMigrator $schemaMigrator = null)
+    {
+        $this->sqlReader = $sqlReader ?: GeneralUtility::makeInstance(SqlReader::class);
+        $this->schemaMigrator = $schemaMigrator ?: GeneralUtility::makeInstance(SchemaMigrator::class);
+    }
+
+    /**
+     * Get all schema updates that are considered (relatively) safe
+     *
+     * @return array
+     */
+    public function getSafeUpdates()
+    {
+        $sqlStatements = $this->sqlReader->getCreateTableStatementArray($this->sqlReader->getTablesDefinitionString());
+        $addCreateChange = $this->schemaMigrator->getUpdateSuggestions($sqlStatements);
+
+        // Aggregate the per-connection statements into one flat array
+        return call_user_func_array('array_merge_recursive', array_values($addCreateChange));
+    }
+
+    /**
+     * Get all schema updates that are destructive (renaming/ deleting fields/ tables)
+     *
+     * @return array
+     */
+    public function getDestructiveUpdates()
+    {
+        $sqlStatements = $this->sqlReader->getCreateTableStatementArray($this->sqlReader->getTablesDefinitionString());
+        // Difference from current to expected
+        $dropRename = $this->schemaMigrator->getUpdateSuggestions($sqlStatements, true);
+
+        // Aggregate the per-connection statements into one flat array
+        return call_user_func_array('array_merge_recursive', array_values($dropRename));
+    }
+
+    /**
+     * Actually execute the migration to the new schema
+     *
+     * @param array $statements
+     * @param array $selectedStatements
+     * @return array
+     */
+    public function migrate(array $statements, array $selectedStatements)
+    {
+        return $this->schemaMigrator->migrate($statements, $selectedStatements);
+    }
+}

--- a/Classes/Database/Schema/SchemaUpdateInterface.php
+++ b/Classes/Database/Schema/SchemaUpdateInterface.php
@@ -1,0 +1,43 @@
+<?php
+namespace Helhum\Typo3Console\Database\Schema;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/**
+ * The database schema update contract
+ */
+interface SchemaUpdateInterface
+{
+    /**
+     * Get all schema updates that are considered (relatively) safe
+     *
+     * @return array
+     */
+    public function getSafeUpdates();
+
+    /**
+     * Get all schema updates that are destructive (renaming/ deleting fields/ tables)
+     *
+     * @return array
+     */
+    public function getDestructiveUpdates();
+
+    /**
+     * Actually execute the migration to the new schema
+     *
+     * @param array $statements
+     * @param array $selectedStatements
+     * @return array
+     */
+    public function migrate(array $statements, array $selectedStatements);
+}

--- a/Classes/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Database/Schema/SchemaUpdateType.php
@@ -166,7 +166,7 @@ class SchemaUpdateType extends Enumeration
                 $expandedSchemaUpdateTypes[] = $schemaUpdateType;
             }
         }
-
+        $expandedSchemaUpdateTypes = array_unique($expandedSchemaUpdateTypes);
         // Cast to enumeration objects to ensure valid values
         foreach ($expandedSchemaUpdateTypes as &$schemaUpdateType) {
             try {

--- a/Classes/Service/Database/SchemaService.php
+++ b/Classes/Service/Database/SchemaService.php
@@ -13,6 +13,7 @@ namespace Helhum\Typo3Console\Service\Database;
  *
  */
 
+use Helhum\Typo3Console\Database\Schema\SchemaUpdateInterface;
 use Helhum\Typo3Console\Database\Schema\SchemaUpdateResult;
 use Helhum\Typo3Console\Database\Schema\SchemaUpdateType;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -22,18 +23,20 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 class SchemaService implements SingletonInterface
 {
+    /**
+     * @var SchemaUpdateInterface
+     */
+    private $schemaUpdate;
 
     /**
-     * @var \TYPO3\CMS\Install\Service\SqlSchemaMigrationService
-     * @inject
+     * SchemaService constructor.
+     *
+     * @param SchemaUpdateInterface $schemaUpdate
      */
-    protected $schemaMigrationService;
-
-    /**
-     * @var \TYPO3\CMS\Install\Service\SqlExpectedSchemaService
-     * @inject
-     */
-    protected $expectedSchemaService;
+    public function __construct(SchemaUpdateInterface $schemaUpdate)
+    {
+        $this->schemaUpdate = $schemaUpdate;
+    }
 
     /**
      * Perform necessary database schema migrations
@@ -44,15 +47,9 @@ class SchemaService implements SingletonInterface
      */
     public function updateSchema(array $schemaUpdateTypes, $dryRun = false)
     {
-        $expectedSchema = $this->expectedSchemaService->getExpectedDatabaseSchema();
-        $currentSchema = $this->schemaMigrationService->getFieldDefinitions_database();
-
-        $addCreateChange = $this->schemaMigrationService->getDatabaseExtra($expectedSchema, $currentSchema);
-        $dropRename = $this->schemaMigrationService->getDatabaseExtra($currentSchema, $expectedSchema);
-
         $updateStatements = [
-            SchemaUpdateType::GROUP_SAFE => $this->schemaMigrationService->getUpdateSuggestions($addCreateChange),
-            SchemaUpdateType::GROUP_DESTRUCTIVE => $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove'),
+            SchemaUpdateType::GROUP_SAFE => $this->schemaUpdate->getSafeUpdates(),
+            SchemaUpdateType::GROUP_DESTRUCTIVE => $this->schemaUpdate->getDestructiveUpdates(),
         ];
 
         $updateResult = new SchemaUpdateResult();
@@ -61,15 +58,18 @@ class SchemaService implements SingletonInterface
             foreach ($schemaUpdateType->getStatementTypes() as $statementType => $statementGroup) {
                 if (isset($updateStatements[$statementGroup][$statementType])) {
                     $statements = $updateStatements[$statementGroup][$statementType];
+                    if (empty($statements)) {
+                        continue;
+                    }
                     if ($dryRun) {
                         $updateResult->addPerformedUpdates($schemaUpdateType, $statements);
                     } else {
-                        $result = $this->schemaMigrationService->performUpdateQueries(
+                        $result = $this->schemaUpdate->migrate(
                             $statements,
                             // Generate a map of statements as keys and true as values
                             array_combine(array_keys($statements), array_fill(0, count($statements), true))
                         );
-                        if ($result === true) {
+                        if (empty($result)) {
                             $updateResult->addPerformedUpdates($schemaUpdateType, $statements);
                         } else {
                             $updateResult->addErrors($schemaUpdateType, $result);

--- a/Tests/Unit/Database/Schema/SchemaUpdateTypeTest.php
+++ b/Tests/Unit/Database/Schema/SchemaUpdateTypeTest.php
@@ -28,7 +28,21 @@ class SchemaUpdateTypeTest extends UnitTestCase
     {
         return [
             'all' => [
-                '*',
+                ['*'],
+                [
+                    'field.add',
+                    'field.change',
+                    'field.prefix',
+                    'field.drop',
+                    'table.add',
+                    'table.change',
+                    'table.prefix',
+                    'table.drop',
+                    'table.clear',
+                ]
+            ],
+            'all double' => [
+                ['*', '*'],
                 [
                     'field.add',
                     'field.change',
@@ -42,7 +56,7 @@ class SchemaUpdateTypeTest extends UnitTestCase
                 ]
             ],
             'fields' => [
-                'field.*',
+                ['field.*'],
                 [
                     'field.add',
                     'field.change',
@@ -51,7 +65,7 @@ class SchemaUpdateTypeTest extends UnitTestCase
                 ]
             ],
             'tables' => [
-                'table.*',
+                ['table.*'],
                 [
                     'table.add',
                     'table.change',
@@ -61,41 +75,41 @@ class SchemaUpdateTypeTest extends UnitTestCase
                 ]
             ],
             'all add' => [
-                '*.add',
+                ['*.add'],
                 [
                     'field.add',
                     'table.add',
                 ]
             ],
             'all change' => [
-                '*.change',
+                ['*.change'],
                 [
                     'field.change',
                     'table.change',
                 ]
             ],
             'all prefix' => [
-                '*.prefix',
+                ['*.prefix'],
                 [
                     'field.prefix',
                     'table.prefix',
                 ]
             ],
             'all drop' => [
-                '*.drop',
+                ['*.drop'],
                 [
                     'field.drop',
                     'table.drop',
                 ]
             ],
             'all clear' => [
-                '*.clear',
+                ['*.clear'],
                 [
                     'table.clear',
                 ]
             ],
             'all safe' => [
-                'safe',
+                ['safe'],
                 [
                     'field.add',
                     'field.change',
@@ -105,7 +119,7 @@ class SchemaUpdateTypeTest extends UnitTestCase
                 ]
             ],
             'all destructive' => [
-                'destructive',
+                ['destructive'],
                 [
                     'field.prefix',
                     'field.drop',
@@ -119,12 +133,12 @@ class SchemaUpdateTypeTest extends UnitTestCase
     /**
      * @test
      * @dataProvider expandTypesExpandsCorrectlyDataProvider
-     * @param string $expandable
+     * @param string[] $expandables
      * @param string[] $expected
      */
-    public function expandTypesExpandsCorrectly($expandable, array $expected)
+    public function expandTypesExpandsCorrectly(array $expandables, array $expected)
     {
-        $updateTypes = array_map('strval', SchemaUpdateType::expandSchemaUpdateTypes([$expandable]));
+        $updateTypes = array_map('strval', SchemaUpdateType::expandSchemaUpdateTypes($expandables));
         $this->assertSame($expected, $updateTypes);
     }
     /**


### PR DESCRIPTION
Extract TYPO3 version specific code into one class with interface
to be able to register different implementations during runtime.

The database:updateschema command is now fully TYPO3 8.x compatible

Further optimize the output of the command