### PR TITLE
[BUGFIX] Use new db schema migration API correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,8 @@ script:
   - ./typo3cms database:updateschema "*" --verbose
   - ./typo3cms database:export > /dev/null
   - echo "SELECT username from be_users where admin=1;" | ./typo3cms database:import
+  - echo "DROP TABLE fe_users;" | ./typo3cms database:import
+  - ./typo3cms database:updateschema "*" --verbose
   - ./typo3cms frontend:request / > /dev/null
   - ./typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null
   - ./typo3cms configuration:show BE/installToolPassword

--- a/Classes/Database/Schema/SchemaUpdate.php
+++ b/Classes/Database/Schema/SchemaUpdate.php
@@ -83,6 +83,6 @@ class SchemaUpdate implements SchemaUpdateInterface, SingletonInterface
      */
     public function migrate(array $statements, array $selectedStatements)
     {
-        return $this->schemaMigrator->migrate($statements, $selectedStatements);
+        return $this->schemaMigrator->migrate($this->sqlReader->getCreateTableStatementArray($this->sqlReader->getTablesDefinitionString()), $selectedStatements);
     }
 }


### PR DESCRIPTION
Unlike the old API, the migrate method always needs the complete
create table statements to work correctly.

This is why we provide that and ignore the pre-selected statements.