### PR TITLE
[TASK] Use general launcher path

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -62,7 +62,7 @@ class CacheCommandController extends CommandController
      * - pages
      * - system
      *
-     * <b>Example:</b> <code>./typo3cms cache:groups pages,all</code>
+     * <b>Example:</b> <code>typo3cms cache:groups pages,all</code>
      *
      * @param array $groups An array of names (specified as comma separated values) of cache groups to flush
      */
@@ -82,7 +82,7 @@ class CacheCommandController extends CommandController
      *
      * Flushes caches by tags, optionally only caches in specified groups.
      *
-     * <b>Example:</b> <code>./typo3cms cache:flushtags news_123 pages,all</code>
+     * <b>Example:</b> <code>typo3cms cache:flushtags news_123 pages,all</code>
      *
      * @param array $tags Array of tags (specified as comma separated values) to flush.
      * @param array $groups Optional array of groups (specified as comma separated values) for which to flush tags. If no group is specified, caches of all groups are flushed.

--- a/Classes/Command/CleanupCommandController.php
+++ b/Classes/Command/CleanupCommandController.php
@@ -36,7 +36,7 @@ class CleanupCommandController extends CommandController
      *
      * Updates reference index to ensure data integrity
      *
-     * <b>Example:</b> <code>./typo3cms cleanup:updatereferenceindex --dry-run --verbose</code>
+     * <b>Example:</b> <code>typo3cms cleanup:updatereferenceindex --dry-run --verbose</code>
      *
      * @param bool $dryRun If set, index is only checked without performing any action
      * @param bool $verbose Whether or not to output results

--- a/Classes/Command/ConfigurationCommandController.php
+++ b/Classes/Command/ConfigurationCommandController.php
@@ -41,7 +41,7 @@ class ConfigurationCommandController extends CommandController implements Single
      * For this command to succeed, the configuration option(s) must be in
      * LocalConfiguration.php and not be overridden elsewhere.
      *
-     * <b>Example:</b> <code>./typo3cms configuration:remove DB,EXT/EXTCONF/realurl</code>
+     * <b>Example:</b> <code>typo3cms configuration:remove DB,EXT/EXTCONF/realurl</code>
      *
      * @param array $paths Path to system configuration that should be removed. Multiple paths can be specified separated by comma
      * @param bool $force If set, does not ask for confirmation
@@ -75,7 +75,7 @@ class ConfigurationCommandController extends CommandController implements Single
      * If the currently active configuration differs from the value in LocalConfiguration.php
      * the difference between these values is shown.
      *
-     * <b>Example:</b> <code>./typo3cms configuration:show DB</code>
+     * <b>Example:</b> <code>typo3cms configuration:show DB</code>
      *
      * @param string $path Path to system configuration option
      */
@@ -107,7 +107,7 @@ class ConfigurationCommandController extends CommandController implements Single
      * Shows active system configuration by path.
      * Shows the configuration value that is currently effective, no matter where and how it is set.
      *
-     * <b>Example:</b> <code>./typo3cms configuration:showActive DB</code>
+     * <b>Example:</b> <code>typo3cms configuration:showActive DB</code>
      *
      * @param string $path Path to system configuration
      */
@@ -126,9 +126,9 @@ class ConfigurationCommandController extends CommandController implements Single
      *
      * Shows local configuration option value by path.
      * Shows the value which is stored in LocalConfiguration.php.
-     * Note that this value could be overridden. Use <code>./typo3cms configuration:show [path]</code> to see if this is the case.
+     * Note that this value could be overridden. Use <code>typo3cms configuration:show [path]</code> to see if this is the case.
      *
-     * <b>Example:</b> <code>./typo3cms configuration:showLocal DB</code>
+     * <b>Example:</b> <code>typo3cms configuration:showLocal DB</code>
      *
      * @param string $path Path to local system configuration
      * @see typo3_console:configuration:show
@@ -148,7 +148,7 @@ class ConfigurationCommandController extends CommandController implements Single
      *
      * Set system configuration option value by path.
      *
-     * <b>Example:</b> <code>./typo3cms configuration:set SYS/fileCreateMask 0664</code>
+     * <b>Example:</b> <code>typo3cms configuration:set SYS/fileCreateMask 0664</code>
      *
      * @param string $path Path to system configuration
      * @param string $value Value for system configuration

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -68,7 +68,7 @@ class DatabaseCommandController extends CommandController
      *
      * To avoid shell matching all types with wildcards should be quoted.
      *
-     * <b>Example:</b> <code>./typo3cms database:updateschema "*.add,*.change"</code>
+     * <b>Example:</b> <code>typo3cms database:updateschema "*.add,*.change"</code>
      *
      * @param array $schemaUpdateTypes List of schema update types (default: "safe")
      * @param bool $verbose If set, database queries performed are shown in output
@@ -106,9 +106,9 @@ class DatabaseCommandController extends CommandController
      * The mysql binary must be available in the path for this command to work.
      * This obviously only works when MySQL is used as DBMS.
      *
-     * <b>Example (import):</b> <code>ssh remote.server '/path/to/typo3cms database:export' | ./typo3cms database:import</code>
-     * <b>Example (select):</b> <code>echo 'SELECT username from be_users WHERE admin=1;' | ./typo3cms database:import</code>
-     * <b>Example (interactive):</b> <code>./typo3cms database:import --interactive</code>
+     * <b>Example (import):</b> <code>ssh remote.server '/path/to/typo3cms database:export' | typo3cms database:import</code>
+     * <b>Example (select):</b> <code>echo 'SELECT username from be_users WHERE admin=1;' | typo3cms database:import</code>
+     * <b>Example (interactive):</b> <code>typo3cms database:import --interactive</code>
      *
      * <warning>This command passes the plain text database password to the command line process.</warning>
      * This means, that users that have the permission to observe running processes,

--- a/Classes/Command/HelpCommandController.php
+++ b/Classes/Command/HelpCommandController.php
@@ -49,7 +49,7 @@ class HelpCommandController extends CommandController
      * Display help for a command
      *
      * The help command displays help for a given command:
-     * ./typo3cms help <command identifier>
+     * typo3cms help <command identifier>
      *
      * @param string $commandIdentifier Identifier of a command for more details
      * @param bool $raw Raw output of commands only

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -98,7 +98,7 @@ class InstallCommandController extends CommandController
      * - All core extensions that are required (or part of minimal usable system)
      * - All core extensions which are provided in the TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS environment variable. Extension keys in this variable must be separated by comma and without spaces.
      *
-     * <b>Example:</b> <code>TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS="info,info_pagetsconfig" ./typo3cms install:generatepackagestates</code>
+     * <b>Example:</b> <code>TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS="info,info_pagetsconfig" typo3cms install:generatepackagestates</code>
      *
      * @param bool $removeInactive Inactive extensions are <comment>removed</comment> from <code>typo3/sysext</code>. <comment>Handle with care!</comment>
      * @param bool $activateDefault If true, <code>typo3/cms</code> extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.

--- a/Classes/Command/SchedulerCommandController.php
+++ b/Classes/Command/SchedulerCommandController.php
@@ -31,7 +31,7 @@ class SchedulerCommandController extends CommandController
      *
      * Executes tasks that are registered in the scheduler module.
      *
-     * <b>Example:</b> <code>./typo3cms scheduler:run 42 --force</code>
+     * <b>Example:</b> <code>typo3cms scheduler:run 42 --force</code>
      *
      * @param int $taskId Uid of the task that should be executed (instead of all scheduled tasks)
      * @param bool $force The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -9,14 +9,14 @@ Command Reference
 
 .. note::
 
-  This reference uses ``./typo3cms`` as the command to invoke. If you are on
+  This reference uses ``typo3cms`` as the command to invoke. If you are on
   Windows, this will probably not work, there you need to use ``typo3cms.bat``
   instead.
   In Composer based installations, the ``typo3cms`` binary will be located
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2016-11-01 13:03:01
+The following reference was automatically generated from code on 2016-12-21 12:30:03
 
 
 .. _`Command Reference: typo3_console`:
@@ -179,7 +179,7 @@ Valid group names are by default:
 - pages
 - system
 
-**Example:** ``./typo3cms cache:groups pages,all``
+**Example:** ``typo3cms cache:groups pages,all``
 
 Arguments
 ^^^^^^^^^
@@ -202,7 +202,7 @@ Arguments
 
 Flushes caches by tags, optionally only caches in specified groups.
 
-**Example:** ``./typo3cms cache:flushtags news_123 pages,all``
+**Example:** ``typo3cms cache:flushtags news_123 pages,all``
 
 Arguments
 ^^^^^^^^^
@@ -246,7 +246,7 @@ Lists all registered cache groups.
 
 Updates reference index to ensure data integrity
 
-**Example:** ``./typo3cms cleanup:updatereferenceindex --dry-run --verbose``
+**Example:** ``typo3cms cleanup:updatereferenceindex --dry-run --verbose``
 
 
 
@@ -276,7 +276,7 @@ Removes a system configuration option by path.
 For this command to succeed, the configuration option(s) must be in
 LocalConfiguration.php and not be overridden elsewhere.
 
-**Example:** ``./typo3cms configuration:remove DB,EXT/EXTCONF/realurl``
+**Example:** ``typo3cms configuration:remove DB,EXT/EXTCONF/realurl``
 
 Arguments
 ^^^^^^^^^
@@ -305,7 +305,7 @@ Options
 
 Set system configuration option value by path.
 
-**Example:** ``./typo3cms configuration:set SYS/fileCreateMask 0664``
+**Example:** ``typo3cms configuration:set SYS/fileCreateMask 0664``
 
 Arguments
 ^^^^^^^^^
@@ -332,7 +332,7 @@ Shows system configuration value by path.
 If the currently active configuration differs from the value in LocalConfiguration.php
 the difference between these values is shown.
 
-**Example:** ``./typo3cms configuration:show DB``
+**Example:** ``typo3cms configuration:show DB``
 
 Arguments
 ^^^^^^^^^
@@ -356,7 +356,7 @@ Arguments
 Shows active system configuration by path.
 Shows the configuration value that is currently effective, no matter where and how it is set.
 
-**Example:** ``./typo3cms configuration:showActive DB``
+**Example:** ``typo3cms configuration:showActive DB``
 
 Arguments
 ^^^^^^^^^
@@ -379,9 +379,9 @@ Arguments
 
 Shows local configuration option value by path.
 Shows the value which is stored in LocalConfiguration.php.
-Note that this value could be overridden. Use ``./typo3cms configuration:show [path]`` to see if this is the case.
+Note that this value could be overridden. Use ``typo3cms configuration:show [path]`` to see if this is the case.
 
-**Example:** ``./typo3cms configuration:showLocal DB``
+**Example:** ``typo3cms configuration:showLocal DB``
 
 Arguments
 ^^^^^^^^^
@@ -435,9 +435,9 @@ it but works as well to pass SELECT statements to it.
 The mysql binary must be available in the path for this command to work.
 This obviously only works when MySQL is used as DBMS.
 
-**Example (import):** ``ssh remote.server '/path/to/typo3cms database:export' | ./typo3cms database:import``
-**Example (select):** ``echo 'SELECT username from be_users WHERE admin=1;' | ./typo3cms database:import``
-**Example (interactive):** ``./typo3cms database:import --interactive``
+**Example (import):** ``ssh remote.server '/path/to/typo3cms database:export' | typo3cms database:import``
+**Example (select):** ``echo 'SELECT username from be_users WHERE admin=1;' | typo3cms database:import``
+**Example (interactive):** ``typo3cms database:import --interactive``
 
 **This command passes the plain text database password to the command line process.**
 This means, that users that have the permission to observe running processes,
@@ -485,7 +485,7 @@ The list of schema update types supports wildcards to specify multiple types, e.
 
 To avoid shell matching all types with wildcards should be quoted.
 
-**Example:** ``./typo3cms database:updateschema "*.add,*.change"``
+**Example:** ``typo3cms database:updateschema "*.add,*.change"``
 
 
 
@@ -711,7 +711,7 @@ Arguments
 Display help for a command
 
 The help command displays help for a given command:
-./typo3cms help <command identifier>
+typo3cms help <command identifier>
 
 
 
@@ -760,7 +760,7 @@ Marks the following extensions as active:
 - All core extensions that are required (or part of minimal usable system)
 - All core extensions which are provided in the TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS environment variable. Extension keys in this variable must be separated by comma and without spaces.
 
-**Example:** ``TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS="info,info_pagetsconfig" ./typo3cms install:generatepackagestates``
+**Example:** ``TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS="info,info_pagetsconfig" typo3cms install:generatepackagestates``
 
 
 
@@ -831,7 +831,7 @@ Options
 
 Executes tasks that are registered in the scheduler module.
 
-**Example:** ``./typo3cms scheduler:run 42 --force``
+**Example:** ``typo3cms scheduler:run 42 --force``
 
 
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -31,26 +31,26 @@ This extension comes with a command line tool called ``typo3cms`` and you can ex
 .. code-block:: bash
 
 	# Run reference index check
-	./typo3cms cleanup:updatereferenceindex --dry-run
+	typo3cms cleanup:updatereferenceindex --dry-run
 
 	# Update translated labels
-	./typo3cms language:update
+	typo3cms language:update
 
 	# Lock editing in the backend
-	./typo3cms backend:lock
+	typo3cms backend:lock
 
 Additionally it provides some commands, that wouldn't be possible at all with the current core command line interface:
 
 .. code-block:: bash
 
 	# Force flush all caches in a reliable and robust way
-	./typo3cms cache:flush --force
+	typo3cms cache:flush --force
 
 	# Interactively set up a new TYPO3 instance from command line (instead of using the install tool)
-	./typo3cms install:setup
+	typo3cms install:setup
 
 	# Non interactive automatic setup of a new TYPO3 instance
-	./typo3cms install:setup --non-interactive \
+	typo3cms install:setup --non-interactive \
 		--database-user-name="root" \
 		--database-host-name="localhost" \
 		--database-port="3306" \
@@ -60,17 +60,17 @@ Additionally it provides some commands, that wouldn't be possible at all with th
 		--site-name="Travis Install"
 
 	# Perform safe database schema updates
-	./typo3cms database:updateschema "*.add,*.change"
+	typo3cms database:updateschema "*.add,*.change"
 
 A help system is integrated, so that you can easily list all available commands or get help for individual commands:
 
 .. code-block:: bash
 
 	# List all commands with a short description
-	./typo3cms help
+	typo3cms help
 
 	# Show detailed help for an individual command
-	./typo3cms help cache:flush
+	typo3cms help cache:flush
 
 
 FAQ

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Instead of typing
 just type:
 
 ```
-./typo3cms extension:activate realurl
+typo3cms extension:activate realurl
 ```
+
+Notice that the location of `typo3cms` depends on your installation type, see *Installation* below.
 
 ## Features
 * Command line tool

--- a/Resources/Private/CommandReference/Templates/CommandReferenceTemplate.txt
+++ b/Resources/Private/CommandReference/Templates/CommandReferenceTemplate.txt
@@ -8,7 +8,7 @@
 
 .. note::
 
-  This reference uses ``./typo3cms`` as the command to invoke. If you are on
+  This reference uses ``typo3cms`` as the command to invoke. If you are on
   Windows, this will probably not work, there you need to use ``typo3cms.bat``
   instead.
   In Composer based installations, the ``typo3cms`` binary will be located


### PR DESCRIPTION
The launcher path strongly depends on the installation type and in
case of Composer also on the configuration, thus use a general path
throughout the code and docs.