### PR TITLE
[BUGFIX] Hide password when typing

### DIFF
--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -233,7 +233,7 @@ class CliSetupRequestHandler
                     do {
                         $defaultValue = $argument->getDefaultValue();
                         $isRequired = $this->isArgumentRequired($argument);
-                        if ($isPasswordArgument && $isRequired) {
+                        if ($isPasswordArgument) {
                             $argumentValue = $this->output->askHiddenResponse(
                                 sprintf(
                                     '<comment>%s:</comment> ',


### PR DESCRIPTION
The hidden input for a password broke during refactoring.
Fix the check again.