### PR TITLE
[BUGFIX] Avoid wrong and unnecessary database schema changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,11 @@ script:
   - typo3cms extension:list --raw | grep extbase
   - typo3cms extension:list --active --raw | grep extbase
   - typo3cms extension:list --inactive --raw | tr '\n' ' ' | grep -v extbase
+  - cp -r Tests/Functional/Fixtures/ext_test .Build/Web/typo3conf/ext/
+  - typo3cms extension:activate ext_test && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - typo3cms extension:activate core && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - typo3cms extension:setup core && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'
 
 after_script:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_script:
   - git clean -dffx
   - composer require typo3/cms="$TYPO3_VERSION"
   - export TYPO3_PATH_WEB="$PWD/.Build/Web"
-  - ln -s Scripts/typo3cms typo3cms
+  - export PATH="$PATH:./Scripts"
 
 script:
   - >
@@ -81,48 +81,48 @@ script:
   # Basic functional tests - all commands should exit with 0
   - >
     if [ -n "$TRAVIS_TAG" ]; then
-      ./typo3cms | grep $TRAVIS_TAG
+      typo3cms | grep $TRAVIS_TAG
     fi
-  - ./typo3cms help && [ ! -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
-  - ./typo3cms install:setup --non-interactive --database-user-name="root" --database-host-name="localhost" --database-port="3306" --database-name="travis_test" --admin-user-name="admin" --admin-password="password" --site-name="Travis Install" --site-setup-type="createsite"
-  - echo 'select uid,title from pages limit 1' | ./typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home
-  - ./typo3cms help
-  - ./typo3cms help:autocomplete
-  - ./typo3cms help:autocomplete bash
-  - ./typo3cms help:autocomplete zsh
-  - ./typo3cms backend:lock
-  - ./typo3cms backend:unlock
-  - ./typo3cms backend:lockforeditors
-  - ./typo3cms backend:unlockforeditors
-  - ./typo3cms cache:flush
-  - ./typo3cms cache:flushgroups pages
-  - ./typo3cms cache:flushtags foo
-  - ./typo3cms cache:flushtags foo pages
-  - ./typo3cms cache:listgroups
-  - ./typo3cms cleanup:updatereferenceindex
-  - ./typo3cms database:updateschema "*" --verbose --dry-run
-  - ./typo3cms database:updateschema --verbose
-  - ./typo3cms database:updateschema "*" --verbose
-  - ./typo3cms database:export > /dev/null
-  - echo "SELECT username from be_users where admin=1;" | ./typo3cms database:import
-  - echo "DROP TABLE fe_users;" | ./typo3cms database:import
-  - ./typo3cms database:updateschema "*" --verbose
-  - ./typo3cms frontend:request / > /dev/null
-  - ./typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null
-  - ./typo3cms configuration:show BE/installToolPassword
-  - ./typo3cms configuration:showLocal BE/installToolPassword
-  - ./typo3cms configuration:showActive BE/installToolPassword
-  - ./typo3cms configuration:set BE/installToolPassword foobar && grep installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep foobar
-  - ./typo3cms configuration:remove BE/installToolPassword --force && grep -qv installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
-  - ./typo3cms configuration:set BE/installToolPassword blablupp && grep installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep blablupp
-  - ./typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
-  - ./typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep baz
-  - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && ./typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
-  - rm $TYPO3_PATH_WEB/typo3temp/index.html && ./typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_WEB/typo3temp/index.html" ]
-  - ./typo3cms extension:list
-  - ./typo3cms extension:list --raw | grep extbase
-  - ./typo3cms extension:list --active --raw | grep extbase
-  - ./typo3cms extension:list --inactive --raw | tr '\n' ' ' | grep -v extbase
+  - typo3cms help && [ ! -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
+  - typo3cms install:setup --non-interactive --database-user-name="root" --database-host-name="localhost" --database-port="3306" --database-name="travis_test" --admin-user-name="admin" --admin-password="password" --site-name="Travis Install" --site-setup-type="createsite"
+  - echo 'select uid,title from pages limit 1' | typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home
+  - typo3cms help
+  - typo3cms help:autocomplete
+  - typo3cms help:autocomplete bash
+  - typo3cms help:autocomplete zsh
+  - typo3cms backend:lock
+  - typo3cms backend:unlock
+  - typo3cms backend:lockforeditors
+  - typo3cms backend:unlockforeditors
+  - typo3cms cache:flush
+  - typo3cms cache:flushgroups pages
+  - typo3cms cache:flushtags foo
+  - typo3cms cache:flushtags foo pages
+  - typo3cms cache:listgroups
+  - typo3cms cleanup:updatereferenceindex
+  - typo3cms database:updateschema "*" --verbose --dry-run
+  - typo3cms database:updateschema --verbose
+  - typo3cms database:updateschema "*" --verbose
+  - typo3cms database:export > /dev/null
+  - echo "SELECT username from be_users where admin=1;" | typo3cms database:import
+  - echo "DROP TABLE fe_users;" | typo3cms database:import
+  - typo3cms database:updateschema "*" --verbose
+  - typo3cms frontend:request / > /dev/null
+  - typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null
+  - typo3cms configuration:show BE/installToolPassword
+  - typo3cms configuration:showLocal BE/installToolPassword
+  - typo3cms configuration:showActive BE/installToolPassword
+  - typo3cms configuration:set BE/installToolPassword foobar && grep installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep foobar
+  - typo3cms configuration:remove BE/installToolPassword --force && grep -qv installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
+  - typo3cms configuration:set BE/installToolPassword blablupp && grep installToolPassword $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep blablupp
+  - typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
+  - typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep baz
+  - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
+  - rm $TYPO3_PATH_WEB/typo3temp/index.html && typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_WEB/typo3temp/index.html" ]
+  - typo3cms extension:list
+  - typo3cms extension:list --raw | grep extbase
+  - typo3cms extension:list --active --raw | grep extbase
+  - typo3cms extension:list --inactive --raw | tr '\n' ' ' | grep -v extbase
 
 after_script:
   - >

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -143,9 +143,10 @@ class InstallCommandController extends CommandController
      */
     public function fixFolderStructureCommand()
     {
-        $folderStructureFactory = GeneralUtility::makeInstance(ExtensionFactory::class, $this->packageManager);
-        $structureFacade = $folderStructureFactory->getStructure();
-        $fixedStatusObjects = $structureFacade->fix();
+        $folderStructureFactory = new ExtensionFactory($this->packageManager);
+        $fixedStatusObjects = $folderStructureFactory
+            ->getStructure()
+            ->fix();
 
         if (empty($fixedStatusObjects)) {
             $this->outputLine('<info>No action performed!</info>');

--- a/Classes/Extension/ExtensionSetup.php
+++ b/Classes/Extension/ExtensionSetup.php
@@ -1,0 +1,87 @@
+<?php
+namespace Helhum\Typo3Console\Extension;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Database\Schema\SchemaUpdateType;
+use Helhum\Typo3Console\Install\FolderStructure\ExtensionFactory;
+use Helhum\Typo3Console\Service\Database\SchemaService;
+use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
+
+/**
+ * Class ExtensionSetup
+ */
+class ExtensionSetup
+{
+    /**
+     * @var ExtensionFactory
+     */
+    private $extensionFactory;
+
+    /**
+     * @var InstallUtility
+     */
+    private $extensionInstaller;
+
+    /**
+     * @var SchemaService
+     */
+    private $schemaService;
+
+    public function __construct(
+        ExtensionFactory $extensionFactory = null,
+        InstallUtility $extensionInstaller = null,
+        SchemaService $schemaService = null
+    ) {
+        $this->extensionFactory = $extensionFactory ?: new ExtensionFactory(GeneralUtility::makeInstance(PackageManager::class));
+        $this->extensionInstaller = $extensionInstaller ?: GeneralUtility::makeInstance(ObjectManager::class)->get(InstallUtility::class);
+        $this->schemaService = $schemaService ?: GeneralUtility::makeInstance(ObjectManager::class)->get(SchemaService::class);
+    }
+
+    /**
+     * @param PackageInterface[] $packages
+     */
+    public function setupExtensions(array $packages)
+    {
+        foreach ($packages as $package) {
+            $this->extensionFactory->getExtensionStructure($package)->fix();
+            $this->callInstaller('importInitialFiles', [PathUtility::stripPathSitePrefix($package->getPackagePath()), $package->getPackageKey()]);
+            $this->callInstaller('saveDefaultConfiguration', [$package->getPackageKey()]);
+        }
+
+        $this->schemaService->updateSchema(SchemaUpdateType::expandSchemaUpdateTypes(['safe']));
+
+        foreach ($packages as $package) {
+            $this->callInstaller('importStaticSqlFile', [PathUtility::stripPathSitePrefix($package->getPackagePath())]);
+            $this->callInstaller('importT3DFile', [PathUtility::stripPathSitePrefix($package->getPackagePath())]);
+        }
+    }
+
+    /**
+     * @param string $method
+     * @param array $arguments
+     */
+    private function callInstaller($method, array $arguments)
+    {
+        $installer = $this->extensionInstaller;
+        call_user_func(
+         \Closure::bind(function () use ($installer, $method, $arguments) {
+             return call_user_func_array([$installer, $method], $arguments);
+         }, null, InstallUtility::class));
+    }
+}

--- a/Classes/Property/TypeConverter/ArrayConverter.php
+++ b/Classes/Property/TypeConverter/ArrayConverter.php
@@ -62,7 +62,7 @@ class ArrayConverter extends \TYPO3\CMS\Extbase\Property\TypeConverter\AbstractT
             if ($source === '') {
                 return [];
             } else {
-                return explode($this->getConfiguredStringDelimiter($configuration), $source);
+                return array_filter(array_map('trim', explode($this->getConfiguredStringDelimiter($configuration), $source)));
             }
         }
 

--- a/Tests/Functional/Fixtures/ext_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/ext_test/ext_emconf.php
@@ -1,0 +1,28 @@
+<?php
+$EM_CONF[$_EXTKEY] = [
+  'title' => 'TYPO3 Console',
+  'description' => 'A reliable and powerful command line interface for TYPO3 CMS',
+  'category' => 'cli',
+  'state' => 'stable',
+  'uploadfolder' => 0,
+  'createDirs' => '',
+  'modify_tables' => '',
+  'clearCacheOnLoad' => 0,
+  'author' => 'Helmut Hummel',
+  'author_email' => 'info@helhum.io',
+  'author_company' => 'helhum.io',
+  'version' => '4.1.0',
+  'constraints' =>
+  [
+    'depends' =>
+    [
+      'typo3' => '7.6.0-8.5.99',
+    ],
+    'conflicts' =>
+    [
+    ],
+    'suggests' =>
+    [
+    ],
+  ],
+];

--- a/Tests/Functional/Fixtures/ext_test/ext_tables.sql
+++ b/Tests/Functional/Fixtures/ext_test/ext_tables.sql
@@ -1,0 +1,3 @@
+CREATE TABLE pages (
+	author_email varchar(255) DEFAULT '' NOT NULL
+);


### PR DESCRIPTION
When calling the extension:setupactive command, the console
called TYPO3 API that is usually used when activating extensions.
However this API is called also for extensions, that are already active.

This leads to the situation, that the database schema is changed to what
the individual extension requires. If however another extension is active, that
is based on the currently activated extension, the correct schema is reverted
to state without the depending extension. Although this is fixed again, when the depending extension is processed, these operations impose a lot of overhead.

Even worse, these operations can be destructive, when the schema
changes are destructive. This is e.g. the case when a VARCHAR field is
made smaller, but already contains data exceeding the new smaller field size.

We now do all non database operations on all extensions first, do a
database schema adjustment once taking all extensions into account and lastly
import database tables or t3d files of every extension if needed.

This not only fixes the bug mentioned above, but speeds up the
execution time for this command by a lot, especially in installations
with many active extensions.

Fixes #382