### PR TITLE
[BUGFIX] Reload caches upon extension activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ script:
   - typo3cms extension:list --active --raw | grep extbase
   - typo3cms extension:list --inactive --raw | tr '\n' ' ' | grep -v extbase
   - cp -r Tests/Functional/Fixtures/ext_test .Build/Web/typo3conf/ext/
-  - typo3cms extension:activate ext_test && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - typo3cms extension:activate ext_test && typo3cms cache:flush && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:activate core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setup core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -93,7 +93,7 @@ class DatabaseCommandController extends CommandController
                 '<info>No schema updates %s performed for update type%s:%s</info>',
                 [$dryRun ? 'must be' : 'were',
                 count($expandedSchemaUpdateTypes) > 1 ? 's' : '',
-                PHP_EOL . implode(PHP_EOL, $expandedSchemaUpdateTypes)]
+                PHP_EOL . implode('", "', $expandedSchemaUpdateTypes)]
             );
         }
     }

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -49,6 +49,12 @@ class ExtensionCommandController extends CommandController
     protected $packageManager;
 
     /**
+     * @var \Helhum\Typo3Console\Service\CacheService
+     * @inject
+     */
+    protected $cacheService;
+
+    /**
      * Activate extension(s)
      *
      * Activates one or more extensions by key.
@@ -72,6 +78,8 @@ class ExtensionCommandController extends CommandController
 
         if (!empty($activatedExtensions)) {
             $this->extensionInstaller->reloadCaches();
+            $this->cacheService->flush();
+
             $extensionKeysAsString = implode('", "', $activatedExtensions);
             if (count($activatedExtensions) === 1) {
                 $this->outputLine('<info>Extension "%s" is now active.</info>', [$extensionKeysAsString]);

--- a/Tests/Functional/Fixtures/ext_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/ext_test/ext_emconf.php
@@ -1,7 +1,7 @@
 <?php
 $EM_CONF[$_EXTKEY] = [
-  'title' => 'TYPO3 Console',
-  'description' => 'A reliable and powerful command line interface for TYPO3 CMS',
+  'title' => 'Test Extension',
+  'description' => 'Extension fixture to prove extension setup working correctly',
   'category' => 'cli',
   'state' => 'stable',
   'uploadfolder' => 0,
@@ -11,12 +11,12 @@ $EM_CONF[$_EXTKEY] = [
   'author' => 'Helmut Hummel',
   'author_email' => 'info@helhum.io',
   'author_company' => 'helhum.io',
-  'version' => '4.1.0',
+  'version' => '0.1.0',
   'constraints' =>
   [
     'depends' =>
     [
-      'typo3' => '7.6.0-8.5.99',
+      'typo3' => '4.5.0-',
     ],
     'conflicts' =>
     [

--- a/Tests/Functional/Fixtures/ext_test/ext_localconf.php
+++ b/Tests/Functional/Fixtures/ext_test/ext_localconf.php
@@ -1,0 +1,7 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::makeCategorizable(
+    'ext_test',
+    'tx_exttest_cattest'
+);

--- a/Tests/Functional/Fixtures/ext_test/ext_tables.sql
+++ b/Tests/Functional/Fixtures/ext_test/ext_tables.sql
@@ -1,3 +1,7 @@
 CREATE TABLE pages (
 	author_email varchar(255) DEFAULT '' NOT NULL
 );
+
+CREATE TABLE tx_exttest_cattest (
+	title varchar(255) DEFAULT '' NOT NULL
+);


### PR DESCRIPTION
When switching to our own API for activating extensions,
it was missed that during activation is is necessary to flush
caches before performing setup operations.

Besides that, the signal sent when activating an extension
also was omitted.

So we now manually reload and flush caches and emit the signal
when required.

Fixes #385