### PR TITLE
[FEATURE] Always generate PackageStates.php file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,8 @@ script:
   - typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
   - typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep baz
   - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
+  - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && TYPO3_CONSOLE_TEST_SETUP=yes TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS=yes composer dump-autoload -vv 2>&1 | grep 'generated PackageStates.php' && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
+  - grep sys_note "$TYPO3_PATH_WEB/typo3conf/PackageStates.php"
   - rm $TYPO3_PATH_WEB/typo3temp/index.html && typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_WEB/typo3temp/index.html" ]
   - typo3cms extension:list
   - typo3cms extension:list --raw | grep extbase
@@ -123,6 +125,7 @@ script:
   - typo3cms extension:activate core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setup core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - typo3cms extension:removeinactive --force | grep 'The following directories have been removed'
 
 after_script:
   - >

--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -13,10 +13,14 @@ namespace Helhum\Typo3Console\Composer;
  *
  */
 
+use Composer\IO\IOInterface;
 use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Core\ConsoleBootstrap;
+use Helhum\Typo3Console\Install\PackageStatesGenerator;
 use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
 use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
 use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
+use TYPO3\CMS\Core\Package\PackageInterface;
 
 /**
  * Class for Composer and Extension Manager install scripts
@@ -33,10 +37,82 @@ class InstallerScripts
      */
     public static function setupConsole(ScriptEvent $event)
     {
-        if ($event->getComposer()->getPackage()->getName() === 'helhum/typo3-console') {
+        if (!getenv('TYPO3_CONSOLE_TEST_SETUP') && $event->getComposer()->getPackage()->getName() === 'helhum/typo3-console') {
             return;
         }
+        self::generatePackageStates($event);
         self::installExtension($event);
+    }
+
+    /**
+     * @return bool
+     */
+    private static function hasTypo3Booted()
+    {
+        // Since this code is executed in composer runtime,
+        // we can safely assume that TYPO3 has not been bootstrapped
+        // until this API has been initialized to return true
+        return ConsoleBootstrap::usesComposerClassLoading();
+    }
+
+    /**
+     * @return ConsoleBootstrap
+     */
+    private static function ensureTypo3Booted()
+    {
+        if (!self::hasTypo3Booted()) {
+            define('PATH_site', getenv('TYPO3_PATH_WEB') . '/');
+            $bootstrap = ConsoleBootstrap::create('Production');
+            $bootstrap->initialize(new \Composer\Autoload\ClassLoader());
+        } else {
+            $bootstrap = ConsoleBootstrap::getInstance();
+        }
+        return $bootstrap;
+    }
+
+    /**
+     * @param ScriptEvent $event
+     */
+    private static function generatePackageStates(ScriptEvent $event)
+    {
+        $io = $event->getIO();
+        $pluginConfig = PluginConfig::load($io, $event->getComposer()->getConfig());
+
+        if ($pluginConfig->get('skip-packagestates-write')) {
+            $io->writeError('<warning>It is highly recommended to let the PackageStates.php file be generated automatically</warning>');
+            $io->writeError('<warning>Disabling this functionality will be removed with TYPO3 Console 5.0</warning>');
+            return;
+        }
+        $bootstrap = self::ensureTypo3Booted();
+        $packageManager = $bootstrap->getEarlyInstance(\TYPO3\CMS\Core\Package\PackageManager::class);
+        $packageStateGenerator = new PackageStatesGenerator($packageManager);
+
+        $frameworkExtensions = explode(',', (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'));
+        $activateDefault = (bool)getenv('TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS');
+        $excludedExtensions = $event->isDevMode() ? explode(',', (string)getenv('TYPO3_EXCLUDED_EXTENSIONS')) : [];
+
+        $activatedExtensions = $packageStateGenerator->generate($frameworkExtensions, $activateDefault, $excludedExtensions);
+
+        $io->writeError(
+            sprintf(
+                '<info>The following extensions have been added to the generated PackageStates.php file:</info> %s',
+                implode(', ', array_map(function (PackageInterface $package) {
+                    return $package->getPackageKey();
+                }, $activatedExtensions))
+            ),
+            true,
+            IOInterface::VERBOSE
+        );
+        if ($event->isDevMode() && !empty(getenv('TYPO3_EXCLUDED_EXTENSIONS'))) {
+            $io->writeError(
+                sprintf(
+                    '<info>The following third party extensions were excluded during this process:</info> %s',
+                    getenv('TYPO3_EXCLUDED_EXTENSIONS')
+                ),
+                true,
+                IOInterface::VERBOSE
+            );
+        }
     }
 
     /**

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,11 +19,11 @@ return [
         'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
         'typo3_console:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
+        'typo3_console:extension:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL ,
+        'typo3_console:extension:removeinactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
     ],
     'bootingSteps' => [
-        'typo3_console:install:databasedata' => [
-            'helhum.typo3console:database'
-        ],
+        'typo3_console:install:databasedata' => ['helhum.typo3console:database'],
         'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database'],
         'typo3_console:cache:flush' => ['helhum.typo3console:database'],
     ]

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2017-01-12 00:08:42
+The following reference was automatically generated from code on 2017-01-14 15:13:59
 
 
 .. _`Command Reference: typo3_console`:
@@ -622,6 +622,29 @@ Options
 
 
 
+.. _`Command Reference: typo3_console extension:removeinactive`:
+
+``extension:removeinactive``
+****************************
+
+**Removes all extensions that are not marked as active**
+
+Directories of inactive extension are **removed** from ``typo3/sysext`` and ``typo3conf/ext``.
+This is a one way command with no way back. Don't blame anybody if this command destroys your data.
+**Handle with care!**
+
+
+
+Options
+^^^^^^^
+
+``--force``
+  The option has to be specified, otherwise nothing happens
+
+
+
+
+
 .. _`Command Reference: typo3_console extension:setup`:
 
 ``extension:setup``
@@ -775,10 +798,12 @@ Marks the following extensions as active:
 Options
 ^^^^^^^
 
-``--remove-inactive``
-  Inactive extensions are **removed** from ``typo3/sysext``. **Handle with care!**
+``--framework-extensions``
+  If given, this argument takes precedence over the environment variable
 ``--activate-default``
   If true, ``typo3/cms`` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
+``--excluded-extensions``
+  Extensions in typo3conf/ext/ directory, which should stay inactive
 
 
 

--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -51,6 +51,6 @@ call_user_func(function () {
         // where requiring the main autoload.php is not enough to load extension classes
         require __DIR__ . '/../Classes/Core/ConsoleBootstrap.php';
     }
-    $bootstrap = new \Helhum\Typo3Console\Core\ConsoleBootstrap(getenv('TYPO3_CONTEXT') ?: 'Production');
+    $bootstrap = \Helhum\Typo3Console\Core\ConsoleBootstrap::create(getenv('TYPO3_CONTEXT') ?: 'Production');
     $bootstrap->run($classLoader);
 });

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "typo3/cms-scheduler": "^7.6 || >=8.3.0 <8.6",
 
         "symfony/console": "^2.7 || ^3.0",
-        "symfony/process": "^2.7 || ^3.0"
+        "symfony/process": "^2.7 || ^3.0",
+        "typo3/cms": "dev-master as 8.5.1"
     },
     "require-dev": {
         "namelesscoder/typo3-repository-client": "^1.2.0",


### PR DESCRIPTION
Although it is pretty easy and convenient to add install:generatepackagestates
as command to be run after composer dumped its autoload information,
this isn't yet adopted widely. To change that, we use our plugin
to do so, so that the PackageStates.php file is now always written
on composer invocation.

Hopefully people using composer will eventually stop fiddling
with the extension:activate commands as of the next version of TYPO3 Console