### PR TITLE
[BUGFIX] Remove unnecessary parameter for the "mysql" command

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -125,7 +125,7 @@ class DatabaseCommandController extends CommandController
             new ProcessBuilder()
         );
         $exitCode = $mysqlCommand->mysql(
-            ['--skip-column-names'],
+            [],
             STDIN,
             $this->buildOutputClosure(),
             $interactive


### PR DESCRIPTION
The interactive database command does not show column names.
This is because `--skip-column-names` is appended to the `mysql`
command, and it cannot be overridden.

However, the parameter is not necessary, so it can easily be dropped.