### PR TITLE
[BUGFIX] Remove table.clear update type

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -28,7 +28,6 @@ namespace Helhum\Typo3Console\Command;
  ***************************************************************/
 
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
-use Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateException;
 use Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateResult;
 use Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateType;
 use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
@@ -56,7 +55,6 @@ class DatabaseCommandController extends CommandController {
 		SchemaUpdateType::FIELD_DROP => 'Drop fields',
 		SchemaUpdateType::TABLE_ADD => 'Add tables',
 		SchemaUpdateType::TABLE_CHANGE => 'Change tables',
-		SchemaUpdateType::TABLE_CLEAR => 'Clear tables',
 		SchemaUpdateType::TABLE_PREFIX => 'Prefix tables',
 		SchemaUpdateType::TABLE_DROP => 'Drop tables',
 	);

--- a/Classes/Service/Database/Schema/SchemaService.php
+++ b/Classes/Service/Database/Schema/SchemaService.php
@@ -69,7 +69,6 @@ class SchemaService implements SingletonInterface {
 		SchemaUpdateType::FIELD_DROP => array('drop' => self::STATEMENT_GROUP_DESTRUCTIVE),
 		SchemaUpdateType::TABLE_ADD => array('create_table' => self::STATEMENT_GROUP_SAFE),
 		SchemaUpdateType::TABLE_CHANGE => array('change_table' => self::STATEMENT_GROUP_SAFE),
-		SchemaUpdateType::TABLE_CLEAR => array('clear_table' => self::STATEMENT_GROUP_SAFE),
 		SchemaUpdateType::TABLE_PREFIX => array('change_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
 		SchemaUpdateType::TABLE_DROP => array('drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE),
 	);

--- a/Classes/Service/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Service/Database/Schema/SchemaUpdateType.php
@@ -78,9 +78,4 @@ class SchemaUpdateType extends Enumeration {
 	 * Drop a table
 	 */
 	const TABLE_DROP = 'table.drop';
-
-	/**
-	 * Truncate a table
-	 */
-	const TABLE_CLEAR = 'table.clear';
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "license": "GPL-2.0+",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "require": {
         "typo3/cms-core": ">=6.2.6,<7.3.0"
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,7 +21,7 @@ $EM_CONF[$_EXTKEY] = array (
   'author_company' => '',
   'CGLcompliance' => '',
   'CGLcompliance_note' => '',
-  'version' => '1.1.8',
+  'version' => '1.1.9',
   '_md5_values_when_last_written' => '',
   'constraints' => 
   array (


### PR DESCRIPTION
This operation is implemented in TYPO3 versions lower 8.4
and was meant to trigger a TRUNCATE TABLE in the following
situations:

1. A cache table needs to be cleared
2. An auto_increment field is added, but not the key

However the code was never executed, as these operations are not part
of the install tool database compare action.

Unfortunately typo3_console revived this previously dead code and reveals
a fatal error.

When the auto_increment field exists, but needs a change
(e.g. from INT(11) to INT(10)), then a truncate of these tables is forced.

Since these can be ANY table, it might destroy your data.

Therefore we remove this operation again from typo3_console and let
the code behind it rot in peace.

Fixes: #391