### PR TITLE
[BUGFIX] Remove table.clear update type

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -18,7 +18,6 @@ use Helhum\Typo3Console\Database\Schema\SchemaUpdateType;
 use Helhum\Typo3Console\Mvc\Controller\CommandController;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
-use TYPO3\CMS\Core\Database\Schema\SqlReader;
 
 /**
  * Database command controller
@@ -79,12 +78,6 @@ class DatabaseCommandController extends CommandController
         } catch (\UnexpectedValueException $e) {
             $this->outputLine(sprintf('<error>%s</error>', $e->getMessage()));
             $this->sendAndExit(1);
-        }
-
-        if (class_exists(SqlReader::class)) {
-            $this->outputLine('<error>To avoid data loss, this command has been disabled for TYPO3 8.x and higher</error>');
-            $this->outputLine('<info>Please use newer versions of TYPO3 Console to use this command with newer TYPO3 versions</info>');
-            $this->quit();
         }
 
         $result = $this->schemaService->updateSchema($schemaUpdateTypes);

--- a/Classes/Database/Schema/SchemaUpdateResultRenderer.php
+++ b/Classes/Database/Schema/SchemaUpdateResultRenderer.php
@@ -31,7 +31,6 @@ class SchemaUpdateResultRenderer
         SchemaUpdateType::FIELD_DROP => 'Drop fields',
         SchemaUpdateType::TABLE_ADD => 'Add tables',
         SchemaUpdateType::TABLE_CHANGE => 'Change tables',
-        SchemaUpdateType::TABLE_CLEAR => 'Clear tables',
         SchemaUpdateType::TABLE_PREFIX => 'Prefix tables',
         SchemaUpdateType::TABLE_DROP => 'Drop tables',
     ];

--- a/Classes/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Database/Schema/SchemaUpdateType.php
@@ -67,11 +67,6 @@ class SchemaUpdateType extends Enumeration
     const TABLE_DROP = 'table.drop';
 
     /**
-     * Truncate a table
-     */
-    const TABLE_CLEAR = 'table.clear';
-
-    /**
      * Expands wildcards in schema update types, e.g. field.* or *.change
      *
      * @param array $schemaUpdateTypes List of schema update types

--- a/Classes/Service/Database/SchemaService.php
+++ b/Classes/Service/Database/SchemaService.php
@@ -56,7 +56,6 @@ class SchemaService implements SingletonInterface
         SchemaUpdateType::FIELD_DROP => ['drop' => self::STATEMENT_GROUP_DESTRUCTIVE],
         SchemaUpdateType::TABLE_ADD => ['create_table' => self::STATEMENT_GROUP_SAFE],
         SchemaUpdateType::TABLE_CHANGE => ['change_table' => self::STATEMENT_GROUP_SAFE],
-        SchemaUpdateType::TABLE_CLEAR => ['clear_table' => self::STATEMENT_GROUP_SAFE],
         SchemaUpdateType::TABLE_PREFIX => ['change_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
         SchemaUpdateType::TABLE_DROP => ['drop_table' => self::STATEMENT_GROUP_DESTRUCTIVE],
     ];


### PR DESCRIPTION
This operation is implemented in TYPO3 versions lower 8.4
and was meant to trigger a TRUNCATE TABLE in the following
situations:

1. A cache table needs to be cleared
2. An auto_increment field is added, but not the key

However the code was never executed, as these operations are not part
of the install tool database compare action.

Unfortunately typo3_console revived this previously dead code and reveals
a fatal error.

When the auto_increment field exists, but needs a change
(e.g. from INT(11) to INT(10)), then a truncate of these tables is forced.

Since these can be ANY table, it might destroy your data.

Therefore we remove this operation again from typo3_console and let
the code behind it rot in peace.

Fixes: #391