### PR TITLE
[BUGFIX] Remove table.clear update type

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -56,7 +56,6 @@ class DatabaseCommandController extends CommandController
      * - table.change
      * - table.prefix
      * - table.drop
-     * - table.clear
      * - safe (includes all necessary operations, to add or change fields or tables)
      * - destructive (includes all operations which rename or drop fields or tables)
      *

--- a/Classes/Database/Schema/SchemaUpdateResultRenderer.php
+++ b/Classes/Database/Schema/SchemaUpdateResultRenderer.php
@@ -31,7 +31,6 @@ class SchemaUpdateResultRenderer
         SchemaUpdateType::FIELD_DROP => 'Drop fields',
         SchemaUpdateType::TABLE_ADD => 'Add tables',
         SchemaUpdateType::TABLE_CHANGE => 'Change tables',
-        SchemaUpdateType::TABLE_CLEAR => 'Clear tables',
         SchemaUpdateType::TABLE_PREFIX => 'Prefix tables',
         SchemaUpdateType::TABLE_DROP => 'Drop tables',
     ];

--- a/Classes/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Database/Schema/SchemaUpdateType.php
@@ -62,11 +62,6 @@ class SchemaUpdateType extends Enumeration
     const TABLE_DROP = 'table.drop';
 
     /**
-     * Truncate a table
-     */
-    const TABLE_CLEAR = 'table.clear';
-
-    /**
      * All safe update types
      */
     const GROUP_SAFE = 'safe';
@@ -88,7 +83,6 @@ class SchemaUpdateType extends Enumeration
         self::FIELD_DROP => ['drop' => self::GROUP_DESTRUCTIVE],
         self::TABLE_ADD => ['create_table' => self::GROUP_SAFE],
         self::TABLE_CHANGE => ['change_table' => self::GROUP_SAFE],
-        self::TABLE_CLEAR => ['clear_table' => self::GROUP_SAFE],
         self::TABLE_PREFIX => ['change_table' => self::GROUP_DESTRUCTIVE],
         self::TABLE_DROP => ['drop_table' => self::GROUP_DESTRUCTIVE],
         self::GROUP_SAFE => [
@@ -96,7 +90,6 @@ class SchemaUpdateType extends Enumeration
             self::FIELD_CHANGE,
             self::TABLE_ADD,
             self::TABLE_CHANGE,
-            self::TABLE_CLEAR,
         ],
         self::GROUP_DESTRUCTIVE => [
             self::FIELD_PREFIX,
@@ -113,7 +106,6 @@ class SchemaUpdateType extends Enumeration
             self::TABLE_CHANGE,
             self::TABLE_PREFIX,
             self::TABLE_DROP,
-            self::TABLE_CLEAR,
         ],
     ];
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2016-12-21 23:39:26
+The following reference was automatically generated from code on 2017-01-12 00:08:42
 
 
 .. _`Command Reference: typo3_console`:
@@ -473,7 +473,6 @@ Valid schema update types are:
 - table.change
 - table.prefix
 - table.drop
-- table.clear
 - safe (includes all necessary operations, to add or change fields or tables)
 - destructive (includes all operations which rename or drop fields or tables)
 

--- a/Tests/Unit/Database/Schema/SchemaUpdateTypeTest.php
+++ b/Tests/Unit/Database/Schema/SchemaUpdateTypeTest.php
@@ -38,7 +38,6 @@ class SchemaUpdateTypeTest extends UnitTestCase
                     'table.change',
                     'table.prefix',
                     'table.drop',
-                    'table.clear',
                 ]
             ],
             'all double' => [
@@ -52,7 +51,6 @@ class SchemaUpdateTypeTest extends UnitTestCase
                     'table.change',
                     'table.prefix',
                     'table.drop',
-                    'table.clear',
                 ]
             ],
             'fields' => [
@@ -71,7 +69,6 @@ class SchemaUpdateTypeTest extends UnitTestCase
                     'table.change',
                     'table.prefix',
                     'table.drop',
-                    'table.clear',
                 ]
             ],
             'all add' => [
@@ -102,12 +99,6 @@ class SchemaUpdateTypeTest extends UnitTestCase
                     'table.drop',
                 ]
             ],
-            'all clear' => [
-                ['*.clear'],
-                [
-                    'table.clear',
-                ]
-            ],
             'all safe' => [
                 ['safe'],
                 [
@@ -115,7 +106,6 @@ class SchemaUpdateTypeTest extends UnitTestCase
                     'field.change',
                     'table.add',
                     'table.change',
-                    'table.clear',
                 ]
             ],
             'all destructive' => [


### PR DESCRIPTION
This operation is implemented in TYPO3 versions lower 8.4
and was meant to trigger a TRUNCATE TABLE in the following
situations:

1. A cache table needs to be cleared
2. An auto_increment field is added, but not the key

However the code was never executed, as these operations are not part
of the install tool database compare action.

Unfortunately typo3_console revived this previously dead code and reveals
a fatal error.

When the auto_increment field exists, but needs a change
(e.g. from INT(11) to INT(10)), then a truncate of these tables is forced.

Since these can be ANY table, it might destroy your data.

Therefore we remove this operation again from typo3_console and let
the code behind it rot in peace.

Fixes: #391