### PR TITLE
Ensure TYPO3 master compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ branches:
   only:
     - master
     - develop
-    - /^[0-9]+\.x$/
-    - /^[0-9]+\.[0-9]+\.x$/
-    - /^[0-9]+\.[0-9]+\.[0-9]+$/
+    - /^([0-9]+\.){1,2}(x|[0-9]+)$/
 
 matrix:
   fast_finish: true
@@ -63,12 +61,13 @@ before_script:
   - composer require typo3/cms="$TYPO3_VERSION"
   - export TYPO3_PATH_WEB="$PWD/.Build/Web"
   - export PATH="$PATH:./Scripts"
+  - if [ -d .Build/vendor/typo3/cms/components/testing_framework/core/Build ]; then export TYPO3_BUILD_DIR=".Build/vendor/typo3/cms/components/testing_framework/core/Build"; else export TYPO3_BUILD_DIR=".Build/vendor/typo3/cms/typo3/sysext/core/Build"; fi
 
 script:
   - >
     echo;
     echo "Running unit tests";
-    .Build/bin/phpunit -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTests.xml Tests/Unit/
+    .Build/bin/phpunit -c $TYPO3_BUILD_DIR/UnitTests.xml Tests/Unit/
   - >
     echo;
     echo "Running php lint";

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -16,7 +16,7 @@ namespace Helhum\Typo3Console\Core\Booting;
 use Helhum\Typo3Console\Core\Cache\FakeDatabaseBackend;
 use Helhum\Typo3Console\Core\ConsoleBootstrap;
 use Helhum\Typo3Console\Error\ErrorHandler;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -161,11 +161,8 @@ class Scripts
      */
     public static function initializeAuthenticatedOperations(ConsoleBootstrap $bootstrap)
     {
-        $bootstrap->initializeBackendUser();
+        $bootstrap->initializeBackendUser(CommandLineUserAuthentication::class);
         self::loadCommandLineBackendUser();
-        /** @var $backendUser \TYPO3\CMS\Core\Authentication\BackendUserAuthentication */
-        $backendUser = $GLOBALS['BE_USER'];
-        $backendUser->backendCheckLogin();
         // Global language object on CLI? rly? but seems to be needed by some scheduler tasks :(
         $bootstrap->initializeLanguageObject();
     }
@@ -177,30 +174,36 @@ class Scripts
      */
     protected static function loadCommandLineBackendUser()
     {
-        /** @var BackendUserAuthentication $beUser */
-        $beUser = $GLOBALS['BE_USER'];
-        if ($beUser->user['uid']) {
+        /** @var CommandLineUserAuthentication $backendUser */
+        $backendUser = $GLOBALS['BE_USER'];
+        if ($backendUser->user['uid']) {
             throw new \RuntimeException('Another user was already loaded which is impossible in CLI mode!', 3);
         }
-        $userName = '_cli_lowlevel';
-        $beUser->setBeUserByName($userName);
-        if (!$beUser->user['uid']) {
-            /** @var DatabaseConnection $db */
-            $db = $GLOBALS['TYPO3_DB'];
-            $db->exec_INSERTquery(
-                'be_users',
-                [
-                    'username' => $userName,
-                    'password' => GeneralUtility::getRandomHexString(48)
-                ]
-            );
-            $beUser->setBeUserByName($userName);
-        }
-        if (!$GLOBALS['BE_USER']->user['uid']) {
-            throw new \RuntimeException('No backend user named "' . $userName . '" was found or could not be created! Please create it manually!', 3);
-        }
-        if ($beUser->isAdmin()) {
-            throw new \RuntimeException('CLI backend user "' . $userName . '" was ADMIN which is not allowed!', 3);
+        if (is_callable([$backendUser, 'authenticate'])) {
+            $backendUser->authenticate();
+        } else {
+            // @deprecated can be removed once TYPO3 7.6 support is removed
+            $userName = '_cli_lowlevel';
+            $backendUser->setBeUserByName($userName);
+            if (!$backendUser->user['uid']) {
+                /** @var DatabaseConnection $db */
+                $db = $GLOBALS['TYPO3_DB'];
+                $db->exec_INSERTquery(
+                    'be_users',
+                    [
+                        'username' => $userName,
+                        'password' => GeneralUtility::getRandomHexString(48)
+                    ]
+                );
+                $backendUser->setBeUserByName($userName);
+            }
+            if (!$backendUser->user['uid']) {
+                throw new \RuntimeException('No backend user named "' . $userName . '" was found or could not be created! Please create it manually!', 3);
+            }
+            if ($backendUser->isAdmin()) {
+                throw new \RuntimeException('CLI backend user "' . $userName . '" was ADMIN which is not allowed!', 3);
+            }
+            $backendUser->backendCheckLogin();
         }
     }
 


### PR DESCRIPTION
CLI user handling recently changed in TYPO3, so we adapt to that.
Besides that, we now detect the half baked testing framework as well
and set the paths to the build directory accordingly