### PR TITLE
Restore `--skip-column-names` for non interactive commands

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -124,7 +124,7 @@ class DatabaseCommandController extends CommandController
             new ProcessBuilder()
         );
         $exitCode = $mysqlCommand->mysql(
-            [],
+            $interactive ? [] : ['--skip-column-names'],
             STDIN,
             $this->buildOutputClosure(),
             $interactive


### PR DESCRIPTION
If you pass select statements to the database:import were
previously skipped. To avoid potential breakage of scripts
relying on that, we restore this functionality again,
but disable it for interactive mode.

Related: #390