### PR TITLE
[BUGFIX] Load dbal information if active

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ script:
   - typo3cms extension:activate core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setup core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - if typo3cms extension:list --raw | grep dbal; then typo3cms extension:activate adodb,dbal && typo3cms database:updateschema | grep 'No schema updates were performed'; fi
   - typo3cms extension:removeinactive --force | grep 'The following directories have been removed'
 
 after_script:

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Core\Package\PackageManager;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -136,6 +137,9 @@ class Scripts
      */
     public static function initializeDatabaseConnection(ConsoleBootstrap $bootstrap)
     {
+        if ($bootstrap->getEarlyInstance(PackageManager::class)->isPackageActive('dbal')) {
+            require GeneralUtility::getFileAbsFileName('EXT:dbal/ext_localconf.php');
+        }
         $bootstrap->initializeDatabaseConnection();
     }
 

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -122,6 +122,9 @@ class Scripts
      */
     public static function initializeCachingFramework(ConsoleBootstrap $bootstrap)
     {
+        if ($bootstrap->getEarlyInstance(PackageManager::class)->isPackageActive('dbal')) {
+            require GeneralUtility::getFileAbsFileName('EXT:dbal/ext_localconf.php');
+        }
         $cacheManager = new \TYPO3\CMS\Core\Cache\CacheManager();
         $cacheManager->setCacheConfigurations($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']);
         \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager);
@@ -137,9 +140,6 @@ class Scripts
      */
     public static function initializeDatabaseConnection(ConsoleBootstrap $bootstrap)
     {
-        if ($bootstrap->getEarlyInstance(PackageManager::class)->isPackageActive('dbal')) {
-            require GeneralUtility::getFileAbsFileName('EXT:dbal/ext_localconf.php');
-        }
         $bootstrap->initializeDatabaseConnection();
     }
 


### PR DESCRIPTION
If dbal is an active extension in the current environment the database
initialization has to load dbal configuration before initializing any
database connection object. This patch ensures loading the correct
information from ext_localconf.php (setting Xclass for
 DatabaseConnection).

Fixes: #403