### PR TITLE
[TASK] Raise mysql command timeout to 5 minutes

### DIFF
--- a/Classes/Database/Process/MysqlCommand.php
+++ b/Classes/Database/Process/MysqlCommand.php
@@ -42,6 +42,7 @@ class MysqlCommand
     {
         $this->dbConfig = $dbConfig;
         $this->processBuilder = $processBuilder;
+        $this->processBuilder->setTimeout(300);
     }
 
     /**


### PR DESCRIPTION
The default timeout of Symfony processes is 60 seconds which may
be too small for large database exports/imports.