### PR TITLE
[FEATURE] Let composer packages provide commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 /Resources/Private/ExtensionArtifacts/src/ export-ignore
-/Resources/Private/ExtensionArtifacts/src/ext_localconf.php export-ignore
+/Resources/Private/ExtensionArtifacts/ext_localconf.php export-ignore
 /Resources/Private/CommandReference/ export-ignore
 /Tests/ export-ignore
 /.gitattributes export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /composer.lock
 /typo3cms
 
+/Configuration/Console/AllCommands.php
 /Libraries/*
 /ext_emconf.php
 /ext_icon.png

--- a/Classes/Composer/InstallerScript/GeneratePackageStates.php
+++ b/Classes/Composer/InstallerScript/GeneratePackageStates.php
@@ -1,0 +1,108 @@
+<?php
+namespace Helhum\Typo3Console\Composer\InstallerScript;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Composer\InstallerScriptInterface;
+use Helhum\Typo3Console\Core\ConsoleBootstrap;
+use Helhum\Typo3Console\Install\PackageStatesGenerator;
+use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
+use TYPO3\CMS\Core\Package\PackageInterface;
+
+class GeneratePackageStates implements InstallerScriptInterface
+{
+    /**
+     * @param ScriptEvent $event
+     * @return bool
+     */
+    public function shouldRun(ScriptEvent $event)
+    {
+        return getenv('TYPO3_CONSOLE_TEST_SETUP') || $event->getComposer()->getPackage()->getName() !== 'helhum/typo3-console';
+    }
+
+    /**
+     * @param ScriptEvent $event
+     * @return bool
+     * @throws \RuntimeException
+     * @internal
+     */
+    public function run(ScriptEvent $event)
+    {
+        $io = $event->getIO();
+        $pluginConfig = PluginConfig::load($io, $event->getComposer()->getConfig());
+
+        if ($pluginConfig->get('skip-packagestates-write')) {
+            $io->writeError('<warning>It is highly recommended to let the PackageStates.php file be generated automatically</warning>');
+            $io->writeError('<warning>Disabling this functionality will be removed with TYPO3 Console 5.0</warning>');
+            return;
+        }
+        $bootstrap = self::ensureTypo3Booted();
+        $packageManager = $bootstrap->getEarlyInstance(\TYPO3\CMS\Core\Package\PackageManager::class);
+        $packageStateGenerator = new PackageStatesGenerator($packageManager);
+
+        $frameworkExtensions = explode(',', (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'));
+        $activateDefault = (bool)getenv('TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS');
+        $excludedExtensions = $event->isDevMode() ? explode(',', (string)getenv('TYPO3_EXCLUDED_EXTENSIONS')) : [];
+
+        $activatedExtensions = $packageStateGenerator->generate($frameworkExtensions, $activateDefault, $excludedExtensions);
+
+        $io->writeError(
+            sprintf(
+                '<info>The following extensions have been added to the generated PackageStates.php file:</info> %s',
+                implode(', ', array_map(function (PackageInterface $package) {
+                    return $package->getPackageKey();
+                }, $activatedExtensions))
+            ),
+            true,
+            $io::VERBOSE
+        );
+        if ($event->isDevMode() && !empty(getenv('TYPO3_EXCLUDED_EXTENSIONS'))) {
+            $io->writeError(
+                sprintf(
+                    '<info>The following third party extensions were excluded during this process:</info> %s',
+                    getenv('TYPO3_EXCLUDED_EXTENSIONS')
+                ),
+                true,
+                $io::VERBOSE
+            );
+        }
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    private static function hasTypo3Booted()
+    {
+        // Since this code is executed in composer runtime,
+        // we can safely assume that TYPO3 has not been bootstrapped
+        // until this API has been initialized to return true
+        return ConsoleBootstrap::usesComposerClassLoading();
+    }
+
+    /**
+     * @return ConsoleBootstrap
+     */
+    private static function ensureTypo3Booted()
+    {
+        if (!self::hasTypo3Booted()) {
+            define('PATH_site', getenv('TYPO3_PATH_WEB') . '/');
+            $bootstrap = ConsoleBootstrap::create('Production');
+            $bootstrap->initialize(new \Composer\Autoload\ClassLoader());
+        } else {
+            $bootstrap = ConsoleBootstrap::getInstance();
+        }
+        return $bootstrap;
+    }
+}

--- a/Classes/Composer/InstallerScript/InstallDummyExtension.php
+++ b/Classes/Composer/InstallerScript/InstallDummyExtension.php
@@ -1,0 +1,79 @@
+<?php
+namespace Helhum\Typo3Console\Composer\InstallerScript;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Composer\InstallerScriptInterface;
+use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
+use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
+use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
+
+/**
+ * @deprecated will be removed with 5.0
+ */
+class InstallDummyExtension implements InstallerScriptInterface
+{
+    /**
+     * @param ScriptEvent $event
+     * @return bool
+     */
+    public function shouldRun(ScriptEvent $event)
+    {
+        return getenv('TYPO3_CONSOLE_TEST_SETUP') || $event->getComposer()->getPackage()->getName() !== 'helhum/typo3-console';
+    }
+
+    /**
+     * @param ScriptEvent $event
+     * @return bool
+     * @throws \RuntimeException
+     * @internal
+     */
+    public function run(ScriptEvent $event)
+    {
+        $io = $event->getIO();
+        $composer = $event->getComposer();
+
+        $composerConfig = $composer->getConfig();
+        $typo3Config = Typo3Config::load($composer);
+        $pluginConfig = PluginConfig::load($io, $composerConfig);
+
+        $webDir = $typo3Config->get('web-dir');
+        $filesystem = new Filesystem();
+        $extensionDir = "$webDir/typo3conf/ext/typo3_console";
+
+        if ($pluginConfig->get('install-extension-dummy')) {
+            $io->writeError('<warning>Installation of TYPO3 extension has been deprecated</warning>');
+            $io->writeError('<warning>To get rid of this message, set "install-extension-dummy" option to false</warning>');
+            $io->writeError('<warning>in "extra -> helhum/typo3-console" section of root composer.json</warning>');
+
+            $extResourcesDir = __DIR__ . '/../../../Resources/Private/ExtensionArtifacts';
+            $resources = [
+                'ext_icon.png',
+                'ext_emconf.php',
+            ];
+            foreach ($resources as $resource) {
+                $target = "$extensionDir/$resource";
+                $filesystem->ensureDirectoryExists(dirname($target));
+                $filesystem->copy("$extResourcesDir/$resource", $target);
+            }
+            $io->writeError('<info>TYPO3 Console: Installed TYPO3 extension into TYPO3 extension directory</info>');
+        } else {
+            if (file_exists($extensionDir) || is_dir($extensionDir)) {
+                $filesystem->removeDirectory($extensionDir);
+                $io->writeError('<info>TYPO3 Console: Removed TYPO3 extension from TYPO3 extension directory</info>');
+            }
+        }
+        return true;
+    }
+}

--- a/Classes/Composer/InstallerScript/PopulateCommandConfiguration.php
+++ b/Classes/Composer/InstallerScript/PopulateCommandConfiguration.php
@@ -1,0 +1,80 @@
+<?php
+namespace Helhum\Typo3Console\Composer\InstallerScript;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Composer\InstallerScriptInterface;
+
+/**
+ * Reads console command configuration files from all composer packages in the current project
+ * and writes a file with all command configurations accumulated
+ */
+class PopulateCommandConfiguration implements InstallerScriptInterface
+{
+    /**
+     * This method is called first. setupConsole is not called if this returns false
+     *
+     * @param ScriptEvent $event
+     * @return bool
+     */
+    public function shouldRun(ScriptEvent $event)
+    {
+        return true;
+    }
+
+    /**
+     * Called from Composer
+     *
+     * @param ScriptEvent $event
+     * @return bool
+     * @throws \RuntimeException
+     * @internal
+     */
+    public function run(ScriptEvent $event)
+    {
+        $composer = $event->getComposer();
+        $composerConfig = $composer->getConfig();
+        $basePath = realpath(substr($composerConfig->get('vendor-dir'), 0, -strlen($composerConfig->get('vendor-dir', $composerConfig::RELATIVE_PATHS))));
+        $commandConfiguration = [];
+        foreach ($this->extractPackageMapFromComposer($composer) as $item) {
+            /** @var \Composer\Package\PackageInterface $package */
+            list($package, $installPath) = $item;
+            $installPath = ($installPath ?: $basePath);
+            if (file_exists($commandConfigurationFile = $installPath . '/Configuration/Console/Commands.php')) {
+                $commandConfiguration[$package->getName()] = require $commandConfigurationFile;
+            }
+        }
+        $success = file_put_contents(
+            __DIR__ . '/../../../Configuration/Console/AllCommands.php',
+            '<?php' . chr(10)
+            . 'return '
+            . var_export($commandConfiguration, true)
+            . ';'
+        );
+
+        return $success !== false;
+    }
+
+    /**
+     * @param \Composer\Composer $composer
+     * @return array
+     */
+    private function extractPackageMapFromComposer(\Composer\Composer $composer)
+    {
+        $mainPackage = $composer->getPackage();
+        $autoLoadGenerator = $composer->getAutoloadGenerator();
+        $localRepo = $composer->getRepositoryManager()->getLocalRepository();
+        return $autoLoadGenerator->buildPackageMap($composer->getInstallationManager(), $mainPackage, $localRepo->getCanonicalPackages());
+    }
+}

--- a/Classes/Composer/InstallerScriptInterface.php
+++ b/Classes/Composer/InstallerScriptInterface.php
@@ -1,0 +1,36 @@
+<?php
+namespace Helhum\Typo3Console\Composer;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Composer\Script\Event as ScriptEvent;
+
+interface InstallerScriptInterface
+{
+    /**
+     * This method is called first. setupConsole is not called if this returns false
+     *
+     * @param ScriptEvent $event
+     * @return bool
+     */
+    public function shouldRun(ScriptEvent $event);
+
+    /**
+     * This is executed, when shouldRun returned true
+     *
+     * @param ScriptEvent $event
+     * @return bool Return false if the script failed
+     * @throws \RuntimeException
+     */
+    public function run(ScriptEvent $event);
+}

--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -13,20 +13,25 @@ namespace Helhum\Typo3Console\Composer;
  *
  */
 
-use Composer\IO\IOInterface;
 use Composer\Script\Event as ScriptEvent;
-use Helhum\Typo3Console\Core\ConsoleBootstrap;
-use Helhum\Typo3Console\Install\PackageStatesGenerator;
-use Helhum\Typo3ConsolePlugin\Config as PluginConfig;
-use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
-use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
-use TYPO3\CMS\Core\Package\PackageInterface;
+use Helhum\Typo3Console\Composer\InstallerScript\GeneratePackageStates;
+use Helhum\Typo3Console\Composer\InstallerScript\InstallDummyExtension;
 
 /**
  * Class for Composer and Extension Manager install scripts
  */
 class InstallerScripts
 {
+    /**
+     * Scripts to execute when console is set up
+     *
+     * @var array
+     */
+    private static $scripts = [
+        GeneratePackageStates::class,
+        InstallDummyExtension::class,
+    ];
+
     /**
      * Called from Composer
      *
@@ -37,121 +42,17 @@ class InstallerScripts
      */
     public static function setupConsole(ScriptEvent $event)
     {
-        if (!getenv('TYPO3_CONSOLE_TEST_SETUP') && $event->getComposer()->getPackage()->getName() === 'helhum/typo3-console') {
-            return;
-        }
-        self::generatePackageStates($event);
-        self::installExtension($event);
-    }
-
-    /**
-     * @return bool
-     */
-    private static function hasTypo3Booted()
-    {
-        // Since this code is executed in composer runtime,
-        // we can safely assume that TYPO3 has not been bootstrapped
-        // until this API has been initialized to return true
-        return ConsoleBootstrap::usesComposerClassLoading();
-    }
-
-    /**
-     * @return ConsoleBootstrap
-     */
-    private static function ensureTypo3Booted()
-    {
-        if (!self::hasTypo3Booted()) {
-            define('PATH_site', getenv('TYPO3_PATH_WEB') . '/');
-            $bootstrap = ConsoleBootstrap::create('Production');
-            $bootstrap->initialize(new \Composer\Autoload\ClassLoader());
-        } else {
-            $bootstrap = ConsoleBootstrap::getInstance();
-        }
-        return $bootstrap;
-    }
-
-    /**
-     * @param ScriptEvent $event
-     */
-    private static function generatePackageStates(ScriptEvent $event)
-    {
         $io = $event->getIO();
-        $pluginConfig = PluginConfig::load($io, $event->getComposer()->getConfig());
-
-        if ($pluginConfig->get('skip-packagestates-write')) {
-            $io->writeError('<warning>It is highly recommended to let the PackageStates.php file be generated automatically</warning>');
-            $io->writeError('<warning>Disabling this functionality will be removed with TYPO3 Console 5.0</warning>');
-            return;
-        }
-        $bootstrap = self::ensureTypo3Booted();
-        $packageManager = $bootstrap->getEarlyInstance(\TYPO3\CMS\Core\Package\PackageManager::class);
-        $packageStateGenerator = new PackageStatesGenerator($packageManager);
-
-        $frameworkExtensions = explode(',', (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'));
-        $activateDefault = (bool)getenv('TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS');
-        $excludedExtensions = $event->isDevMode() ? explode(',', (string)getenv('TYPO3_EXCLUDED_EXTENSIONS')) : [];
-
-        $activatedExtensions = $packageStateGenerator->generate($frameworkExtensions, $activateDefault, $excludedExtensions);
-
-        $io->writeError(
-            sprintf(
-                '<info>The following extensions have been added to the generated PackageStates.php file:</info> %s',
-                implode(', ', array_map(function (PackageInterface $package) {
-                    return $package->getPackageKey();
-                }, $activatedExtensions))
-            ),
-            true,
-            IOInterface::VERBOSE
-        );
-        if ($event->isDevMode() && !empty(getenv('TYPO3_EXCLUDED_EXTENSIONS'))) {
-            $io->writeError(
-                sprintf(
-                    '<info>The following third party extensions were excluded during this process:</info> %s',
-                    getenv('TYPO3_EXCLUDED_EXTENSIONS')
-                ),
-                true,
-                IOInterface::VERBOSE
-            );
-        }
-    }
-
-    /**
-     * @param ScriptEvent $event
-     * @deprecated will be removed with 5.0
-     */
-    private static function installExtension(ScriptEvent $event)
-    {
-        $io = $event->getIO();
-        $composer = $event->getComposer();
-
-        $composerConfig = $composer->getConfig();
-        $typo3Config = Typo3Config::load($composer);
-        $pluginConfig = PluginConfig::load($io, $composerConfig);
-
-        $webDir = $typo3Config->get('web-dir');
-        $filesystem = new Filesystem();
-        $extensionDir = "$webDir/typo3conf/ext/typo3_console";
-
-        if ($pluginConfig->get('install-extension-dummy')) {
-            $io->writeError('<warning>Installation of TYPO3 extension has been deprecated</warning>');
-            $io->writeError('<warning>To get rid of this message, set "install-extension-dummy" option to false</warning>');
-            $io->writeError('<warning>in "extra -> helhum/typo3-console" section of root composer.json</warning>');
-
-            $extResourcesDir = __DIR__ . '/../../Resources/Private/ExtensionArtifacts';
-            $resources = [
-                'ext_icon.png',
-                'ext_emconf.php',
-            ];
-            foreach ($resources as $resource) {
-                $target = "$extensionDir/$resource";
-                $filesystem->ensureDirectoryExists(dirname($target));
-                $filesystem->copy("$extResourcesDir/$resource", $target);
-            }
-            $io->writeError('<info>TYPO3 Console: Installed TYPO3 extension into TYPO3 extension directory</info>');
-        } else {
-            if (file_exists($extensionDir) || is_dir($extensionDir)) {
-                $filesystem->removeDirectory($extensionDir);
-                $io->writeError('<info>TYPO3 Console: Removed TYPO3 extension from TYPO3 extension directory</info>');
+        foreach (self::$scripts as $scriptClass) {
+            /** @var InstallerScriptInterface $script */
+            $script = new $scriptClass();
+            if ($script->shouldRun($event)) {
+                $io->writeError(sprintf('<info>Executing "%s": </info>', $scriptClass), true, $io::DEBUG);
+                if (!$script->run($event)) {
+                     $io->writeError(sprintf('<error>Executing "%s" failed!</error>', $scriptClass), true);
+                 }
+            } else {
+                $io->writeError(sprintf('<info>Skipped executing "%s": </info>', $scriptClass), true, $io::DEBUG);
             }
         }
     }

--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -16,6 +16,7 @@ namespace Helhum\Typo3Console\Composer;
 use Composer\Script\Event as ScriptEvent;
 use Helhum\Typo3Console\Composer\InstallerScript\GeneratePackageStates;
 use Helhum\Typo3Console\Composer\InstallerScript\InstallDummyExtension;
+use Helhum\Typo3Console\Composer\InstallerScript\PopulateCommandConfiguration;
 
 /**
  * Class for Composer and Extension Manager install scripts
@@ -28,6 +29,7 @@ class InstallerScripts
      * @var array
      */
     private static $scripts = [
+        PopulateCommandConfiguration::class,
         GeneratePackageStates::class,
         InstallDummyExtension::class,
     ];
@@ -49,8 +51,8 @@ class InstallerScripts
             if ($script->shouldRun($event)) {
                 $io->writeError(sprintf('<info>Executing "%s": </info>', $scriptClass), true, $io::DEBUG);
                 if (!$script->run($event)) {
-                     $io->writeError(sprintf('<error>Executing "%s" failed!</error>', $scriptClass), true);
-                 }
+                    $io->writeError(sprintf('<error>Executing "%s" failed!</error>', $scriptClass), true);
+                }
             } else {
                 $io->writeError(sprintf('<info>Skipped executing "%s": </info>', $scriptClass), true, $io::DEBUG);
             }

--- a/Classes/Core/Booting/Sequence.php
+++ b/Classes/Core/Booting/Sequence.php
@@ -60,7 +60,7 @@ class Sequence
      *
      * @param string $stepIdentifier
      * @return void
-     * @throws \TYPO3\Flow\Exception
+     * @throws \Exception
      */
     public function removeStep($stepIdentifier)
     {
@@ -75,7 +75,7 @@ class Sequence
             }
         }
         if ($removedOccurrences === 0) {
-            throw new \TYPO3\Flow\Exception(sprintf('Cannot remove sequence step with identifier "%s" because no such step exists in the given sequence.', $stepIdentifier), 1322591669);
+            throw new \Exception(sprintf('Cannot remove sequence step with identifier "%s" because no such step exists in the given sequence.', $stepIdentifier), 1322591669);
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,11 @@
             "@extension-build",
             "rm Resources/Private/ExtensionArtifacts/ext_*",
             "rm -rf Tests/",
-            "rm -rf Resources/Private/CommandReference/"
+            "rm -rf Resources/Private/CommandReference/",
+            "rm .gitattributes",
+            "rm .gitignore",
+            "rm .php_cs",
+            "rm .travis.yml"
         ],
         "extension-clean": [
             "rm -rf Libraries",


### PR DESCRIPTION
This changes the bootstrap to load the commands
and the command manager before the RequestHandler
is initialized.

This results in a clearer Bootstrap and enables
commands being executed during composer build time.
Now every composer package (which includes TYPO3 extensions)
is scanned for console command configuration file.
All files are collected and stored in one file during build time.
During runtime this one file is evaluated instead of looping over
all active TYPO3 extensions.

Although this file has a limited format (e.g. command controller
class names must match a certain pattern), we use that
until TYPO3 Console can run native Symfony commands.

Fixes #265