### PR TITLE
[TASK] Simplify package states generation

### DIFF
--- a/Classes/Composer/InstallerScript/InstallDummyExtension.php
+++ b/Classes/Composer/InstallerScript/InstallDummyExtension.php
@@ -30,7 +30,7 @@ class InstallDummyExtension implements InstallerScriptInterface
      */
     public function shouldRun(ScriptEvent $event)
     {
-        return getenv('TYPO3_CONSOLE_TEST_SETUP') || $event->getComposer()->getPackage()->getName() !== 'helhum/typo3-console';
+        return $event->getComposer()->getPackage()->getName() !== 'helhum/typo3-console';
     }
 
     /**

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -119,6 +119,7 @@ class CommandDispatcher
         } else {
             $processBuilder->setPrefix($typo3cmsCommandPath);
         }
+        $processBuilder->addEnvironmentVariables(['TYPO3_CONSOLE_SUB_PROCESS' => true]);
         return new self($processBuilder);
     }
 
@@ -127,15 +128,18 @@ class CommandDispatcher
      *
      * @param string $command Command identifier
      * @param array $arguments Argument names will automatically be converted to dashed version, fi not provided like so
+     * @param array $environment Environment vars to be added to the command
      * @return string Output of the executed command
      * @throws FailedSubProcessCommandException
      */
-    public function executeCommand($command, array $arguments = [])
+    public function executeCommand($command, array $arguments = [], array $environment = [])
     {
         // We need to clone the builder to be able to re-use the object for multiple commands
         $processBuilder = clone $this->processBuilder;
 
         $processBuilder->add($command);
+        $processBuilder->addEnvironmentVariables($environment);
+
         foreach ($arguments as $argumentName => $argumentValue) {
             if (strpos($argumentName, '--') === 0) {
                 $dashedName = $argumentName;

--- a/Classes/Mvc/Cli/ConsoleOutput.php
+++ b/Classes/Mvc/Cli/ConsoleOutput.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput as SymfonyConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
@@ -105,7 +106,11 @@ class ConsoleOutput
         if ($arguments !== []) {
             $text = vsprintf($text, $arguments);
         }
-        $this->output->write($text);
+        if (getenv('TYPO3_CONSOLE_SUB_PROCESS')) {
+            $this->output->write($text, false, OutputInterface::OUTPUT_RAW);
+        } else {
+            $this->output->write($text);
+        }
     }
 
     /**

--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -27,11 +27,11 @@ call_user_func(function () {
     if (file_exists($autoLoadFile = realpath($typo3Root . '/typo3') . '/../vendor/autoload.php')) {
         // The extension is in typo3conf/ext, so we load the main autoload.php from TYPO3 sources
         // Applicable in both Composer and non-Composer mode.
-        $classLoader = require_once $autoLoadFile;
+        $classLoader = require $autoLoadFile;
     } elseif (!empty($vendorDir) && file_exists($autoLoadFile = $vendorDir . '/autoload.php')) {
         // The package is in vendor dir, so we load the main autoload.php from vendor folder
         // Applicable in Composer mode only.
-        $classLoader = require_once $autoLoadFile;
+        $classLoader = require $autoLoadFile;
     } else {
         echo 'Could not find autoload.php file. Is TYPO3_PATH_WEB specified correctly?' . PHP_EOL;
         exit(1);

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "typo3/cms-scheduler": "^7.6 || >=8.3.0 <8.6",
 
         "symfony/console": "^2.7 || ^3.0",
-        "symfony/process": "^2.7 || ^3.0",
-        "typo3/cms": "dev-master as 8.5.1"
+        "symfony/process": "^2.7 || ^3.0"
     },
     "require-dev": {
         "namelesscoder/typo3-repository-client": "^1.2.0",


### PR DESCRIPTION
We can use the newly improved sub process API
instead of manually bootstrapping TYPO3

Also disable this functionality in case prepare-web-dir
is set to false

Fixes #411