### PR TITLE
[BUGFIX] Fix "database:import" on empty database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,11 @@ script:
   - typo3cms database:updateschema "*" --verbose --dry-run
   - typo3cms database:updateschema --verbose
   - typo3cms database:updateschema "*" --verbose
-  - typo3cms database:export > /dev/null
+  - typo3cms database:export > travis_test.sql
   - test $(typo3cms database:export --exclude-tables sys_log | grep "CREATE TABLE" | grep -c sys_log) -eq 0
   - echo "SELECT username from be_users where admin=1;" | typo3cms database:import
-  - echo "DROP TABLE fe_users;" | typo3cms database:import
+  - echo "DROP DATABASE travis_test;" | typo3cms database:import
+  - echo "CREATE DATABASE travis_test;" | mysql -uroot && cat travis_test.sql | typo3cms database:import
   - typo3cms database:updateschema "*" --verbose
   - typo3cms frontend:request / > /dev/null
   - typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null

--- a/Classes/Database/Configuration/ConnectionConfiguration.php
+++ b/Classes/Database/Configuration/ConnectionConfiguration.php
@@ -31,10 +31,10 @@ class ConnectionConfiguration
         } else {
             // @deprecated with 8 will be removed when 7 Support is dropped
             $dbConfig = [
-                'dbname' => TYPO3_db,
-                'host' => TYPO3_db_host,
-                'user' => TYPO3_db_username,
-                'password' => TYPO3_db_password,
+                'dbname' => $GLOBALS['TYPO3_CONF_VARS']['DB']['database'],
+                'host' => $GLOBALS['TYPO3_CONF_VARS']['DB']['host'],
+                'user' => $GLOBALS['TYPO3_CONF_VARS']['DB']['username'],
+                'password' => $GLOBALS['TYPO3_CONF_VARS']['DB']['password'],
             ];
             if (isset($GLOBALS['TYPO3_CONF_VARS']['DB']['port'])) {
                 $dbConfig['port'] = $GLOBALS['TYPO3_CONF_VARS']['DB']['port'];

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,6 +19,7 @@ return [
         'typo3_console:cache:flush' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
         'typo3_console:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
+        'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:extension:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL ,
         'typo3_console:extension:removeinactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
     ],


### PR DESCRIPTION
A common usecase is importing an SQL dump into an empty database, thus
do not require a CLI user by switching to a minimal runlevel.

Also read all DB credentials from configuration in TYPO3 v7 since no
constants are available in minimal runlevel.