### PR TITLE
[TASK] Hide plugin packagestates generation behind feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ script:
   - typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
   - typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php | grep baz
   - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
-  - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && TYPO3_CONSOLE_TEST_SETUP=yes TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS=yes composer dump-autoload -vv 2>&1 | grep 'generated PackageStates.php' && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
+  - rm -f $TYPO3_PATH_WEB/typo3conf/PackageStates.php && TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES=yes TYPO3_CONSOLE_TEST_SETUP=yes TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS=yes composer dump-autoload -vv 2>&1 | grep 'generated PackageStates.php' && [ -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
   - grep sys_note "$TYPO3_PATH_WEB/typo3conf/PackageStates.php"
   - rm $TYPO3_PATH_WEB/typo3temp/index.html && typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_WEB/typo3temp/index.html" ]
   - typo3cms extension:list

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -93,17 +93,18 @@ class InstallCommandController extends CommandController
      *
      * - Third party extensions
      * - All core extensions that are required (or part of minimal usable system)
-     * - All core extensions which are provided in the TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS environment variable. Extension keys in this variable must be separated by comma and without spaces.
+     * - All core extensions which are provided with the <code>--framework-extensions</code> argument.
+     * - In composer mode all composer dependencies to TYPO3 framework extensions are detected and activated by default.
      *
-     * <b>Example:</b> <code>TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS="info,info_pagetsconfig" typo3cms install:generatepackagestates</code>
+     * <b>Example:</b> <code>typo3cms install:generatepackagestates</code>
      *
-     * @param array $frameworkExtensions If given, this argument takes precedence over the environment variable
+     * @param array $frameworkExtensions TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
      * @param bool $activateDefault If true, <code>typo3/cms</code> extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
      * @param array $excludedExtensions Extensions in typo3conf/ext/ directory, which should stay inactive
      */
     public function generatePackageStatesCommand(array $frameworkExtensions = [], $activateDefault = false, array $excludedExtensions = [])
     {
-        $ranFromComposerPlugin = getenv('TYPO3_CONSOLE_PLUGIN_RUN');
+        $ranFromComposerPlugin = getenv('TYPO3_CONSOLE_PLUGIN_RUN') || !getenv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES');
         if (!$ranFromComposerPlugin && Bootstrap::usesComposerClassLoading()) {
             $this->output->outputLine('<warning>This command is now always automatically executed after Composer has written the autoload information.</warning>');
             $this->output->outputLine('<warning>It is therefore deprecated to be used in Composer mode.</warning>');

--- a/Classes/Composer/InstallerScript/GeneratePackageStates.php
+++ b/Classes/Composer/InstallerScript/GeneratePackageStates.php
@@ -28,6 +28,9 @@ class GeneratePackageStates implements InstallerScriptInterface
      */
     public function shouldRun(ScriptEvent $event)
     {
+        if (!getenv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES')) {
+            return false;
+        }
         $io = $event->getIO();
         $composer = $event->getComposer();
         $pluginConfig = PluginConfig::load($io, $composer->getConfig());

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2017-01-26 15:28:42
+The following reference was automatically generated from code on 2017-02-14 21:09:18
 
 
 .. _`Command Reference: typo3_console`:
@@ -799,9 +799,10 @@ Marks the following extensions as active:
 
 - Third party extensions
 - All core extensions that are required (or part of minimal usable system)
-- All core extensions which are provided in the TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS environment variable. Extension keys in this variable must be separated by comma and without spaces.
+- All core extensions which are provided with the ``--framework-extensions`` argument.
+- In composer mode all composer dependencies to TYPO3 framework extensions are detected and activated by default.
 
-**Example:** ``TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS="info,info_pagetsconfig" typo3cms install:generatepackagestates``
+**Example:** ``typo3cms install:generatepackagestates``
 
 
 
@@ -809,7 +810,7 @@ Options
 ^^^^^^^
 
 ``--framework-extensions``
-  If given, this argument takes precedence over the environment variable
+  TYPO3 system extensions that should be marked as active. Extension keys separated by comma.
 ``--activate-default``
   If true, ``typo3/cms`` extensions that are marked as TYPO3 factory default, will be activated, even if not in the list of configured active framework extensions.
 ``--excluded-extensions``


### PR DESCRIPTION
Reason for that is, to be able to get a new release out
before this feature is stable enough and non breaking.