### PR TITLE
[TASK] Mark as compatible with TYPO3 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,17 @@ matrix:
     - php: 7.0
       env: TYPO3_VERSION=~8.5.0
     - php: 7.0
-      env: TYPO3_VERSION="dev-master as 8.5.0"
+      env: TYPO3_VERSION=~8.6.0
+    - php: 7.0
+      env: TYPO3_VERSION="dev-master as 8.6.0"
     - php: 7.1
       env: TYPO3_VERSION=^7.6
     - php: 7.1
       env: TYPO3_VERSION=^8
     - php: 7.1
-      env: TYPO3_VERSION="dev-master as 8.5.0"
+      env: TYPO3_VERSION="dev-master as 8.6.0"
   allow_failures:
-    - env: TYPO3_VERSION="dev-master as 8.5.0"
+    - env: TYPO3_VERSION="dev-master as 8.6.0"
 
 cache:
   directories:
@@ -61,7 +63,7 @@ before_script:
   - composer require typo3/cms="$TYPO3_VERSION"
   - export TYPO3_PATH_WEB="$PWD/.Build/Web"
   - export PATH="$PATH:./Scripts"
-  - if [ -d .Build/vendor/typo3/cms/components/testing_framework/core/Build ]; then export TYPO3_BUILD_DIR=".Build/vendor/typo3/cms/components/testing_framework/core/Build"; else export TYPO3_BUILD_DIR=".Build/vendor/typo3/cms/typo3/sysext/core/Build"; fi
+  - if [ -d .Build/vendor/typo3/cms/components/testing_framework/Resources/Core/Build ]; then export TYPO3_BUILD_DIR=".Build/vendor/typo3/cms/components/testing_framework/Resources/Core/Build"; else export TYPO3_BUILD_DIR=".Build/vendor/typo3/cms/typo3/sysext/core/Build"; fi
 
 script:
   - >

--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = [
   [
     'depends' =>
     [
-      'typo3' => '7.6.0-8.5.99',
+      'typo3' => '7.6.0-8.6.99',
     ],
     'conflicts' =>
     [

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
         "php": ">=5.5.0",
         "helhum/typo3-console-plugin": "^1.5.0",
 
-        "typo3/cms-backend": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-core": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-extbase": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-extensionmanager": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-fluid": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-install": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-saltedpasswords": "^7.6 || >=8.3.0 <8.6",
-        "typo3/cms-scheduler": "^7.6 || >=8.3.0 <8.6",
+        "typo3/cms-backend": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-core": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-extbase": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-extensionmanager": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-fluid": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-install": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-saltedpasswords": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-scheduler": "^7.6 || >=8.3.0 <8.7",
 
         "symfony/console": "^2.7 || ^3.0",
         "symfony/process": "^2.7 || ^3.0"
@@ -63,6 +63,9 @@
         "typo3-ter/typo3-console": "self.version"
     },
     "config": {
+        "preferred-install": {
+            "typo3/cms": "source"
+        },
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin"
     },


### PR DESCRIPTION
TYPO3 Console is battle tested with the current TYPO3 master,
thus we can now safely mark it compatible with the just released
TYPO3 version 8.6.0

Also adapt our build pipeline to the latest breaking changes in the
testing framework and add further builds to include the new TYPO3 version.