### PR TITLE
Add verbose error message for layer 8 issue

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -77,6 +77,15 @@ class ConsoleBootstrap extends Bootstrap
             $this->requestId = uniqid('console_request_', true);
             $this->initializePackageManagement();
 
+            if (!class_exists(RunLevel::class)) {
+                echo sprintf('Could not initialize TYPO3 Console for TYPO3 in path %s.', PATH_site) . chr(10);
+                echo 'This most likely happened because you have a console code checkout in typo3conf/ext/typo3_console,' . chr(10);
+                echo 'but TYPO3 Console is not set up as extension. If you want to use it as extension,' . chr(10);
+                echo 'please download it from https://typo3.org/extensions/repository/view/typo3_console' . chr(10);
+                echo 'or install it properly using Composer.' . chr(10);
+                exit(1);
+            }
+
             $this->runLevel = new RunLevel();
             $this->setEarlyInstance(\Helhum\Typo3Console\Core\Booting\RunLevel::class, $this->runLevel);
             $exceptionHandler = new ExceptionHandler();


### PR DESCRIPTION
When cloning the console repo to typo3conf/ext
but not building the required extension files,
classes cannot be properly loaded by TYPO3 in non
composer mode.

Output a descriptive error message in this case.