### PR TITLE
Simplify contribution workflow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "require-dev": {
         "typo3-console/create-reference-command": "1.0.*@dev",
         "namelesscoder/typo3-repository-client": "^1.2.0",
+        "typo3/cms": "^8.6",
         "mikey179/vfsStream": "~1.6.0",
         "phpunit/phpunit": "~4.8.0"
     },


### PR DESCRIPTION
In order to avoid confusion when contributing to TYPO3 Console,
we now add typo3/cms as dev dependency, which makes it now
possible to use composer install within the console dir
to get a working contribution setup.