### PR TITLE
[BUGFIX] Correctly pass boolean arguments to the sub process

### DIFF
--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -150,7 +150,12 @@ class CommandDispatcher
             }
             $processBuilder->add($dashedName);
             if ($argumentValue !== null) {
-                $processBuilder->add($argumentValue);
+                if ($argumentValue === false) {
+                    // Convert boolean false to 'false' instead of empty string to correctly pass the value to the sub command
+                    $processBuilder->add('false');
+                } else {
+                    $processBuilder->add($argumentValue);
+                }
             }
         }
 


### PR DESCRIPTION
The CLI RequestBuilder maps boolean arguments to a bool, but
does not consider an empty string '' to be a boolean false.

Because such arguments are already converted to boolean in the main
process, we must therefore convert this boolean value to a
string that is then correctly understood by the RequestBuilder as boolean
value.