### PR TITLE
Run database:updateschema with RunLevel::LEVEL_MINIMAL

### DIFF
--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,6 +19,7 @@ return [
         'typo3_console:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
+        'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
         'typo3_console:extension:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL ,
         'typo3_console:extension:removeinactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
     ],

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -19,7 +19,7 @@ return [
         'typo3_console:commandreference:render' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
-        'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
+        'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,
         'typo3_console:extension:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL ,
         'typo3_console:extension:removeinactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE ,
     ],

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -27,5 +27,9 @@ return [
         'typo3_console:install:databasedata' => ['helhum.typo3console:database'],
         'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database'],
         'typo3_console:cache:flush' => ['helhum.typo3console:database'],
+        'typo3_console:database:updateschema' => [
+            'helhum.typo3console:database',
+            'helhum.typo3console:persistence',
+        ],
     ]
 ];


### PR DESCRIPTION
This pull request lowers the run level of database:updateschema to LEVEL_MINIMAL so it can be run without any assumptions of the existing database schema. This is useful if the database is empty.

Fixes #429