### PR TITLE
Cleanly remove anyway overridden command controllers

### DIFF
--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -188,7 +188,7 @@ class ExtensionCommandController extends CommandController
      * As an additional benefit no caches are flushed, which significantly improves performance of this command
      * and avoids unnecessary cache clearing.
      *
-     * @see extensionmanager:extension:setup
+     * @see typo3_console:extension:setup
      * @see typo3_console:install:generatepackagestates
      * @see typo3_console:cache:flush
      */

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -225,8 +225,6 @@ class Scripts
             self::registerImplementation(\Helhum\Typo3Console\Database\Schema\SchemaUpdateInterface::class, \Helhum\Typo3Console\Database\Schema\LegacySchemaUpdate::class);
         }
         self::overrideImplementation(\TYPO3\CMS\Extbase\Mvc\Cli\Command::class, \Helhum\Typo3Console\Mvc\Cli\Command::class);
-        self::overrideImplementation(\TYPO3\CMS\Extbase\Command\HelpCommandController::class, \Helhum\Typo3Console\Command\HelpCommandController::class);
-        self::overrideImplementation(\TYPO3\CMS\Extensionmanager\Command\ExtensionCommandController::class, \Helhum\Typo3Console\Command\ExtensionCommandController::class);
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter(\Helhum\Typo3Console\Property\TypeConverter\ArrayConverter::class);
     }
 

--- a/Classes/Mvc/Cli/CommandManager.php
+++ b/Classes/Mvc/Cli/CommandManager.php
@@ -14,7 +14,9 @@ namespace Helhum\Typo3Console\Mvc\Cli;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Command\HelpCommandController;
 use TYPO3\CMS\Extbase\Mvc\Cli\Command;
+use TYPO3\CMS\Extensionmanager\Command\ExtensionCommandController;
 
 /**
  * Class CommandManager
@@ -56,8 +58,12 @@ class CommandManager extends \TYPO3\CMS\Extbase\Mvc\Cli\CommandManager
      */
     public function getCommandByIdentifier($commandIdentifier)
     {
+        $commandIdentifier = strtolower(trim($commandIdentifier));
+        if ($commandIdentifier === 'help') {
+            $commandIdentifier = 'typo3_console:help:help';
+        }
         if ($commandIdentifier === 'autocomplete') {
-            $commandIdentifier = 'extbase:help:autocomplete';
+            $commandIdentifier = 'typo3_console:help:autocomplete';
         }
         return parent::getCommandByIdentifier($commandIdentifier);
     }
@@ -68,7 +74,10 @@ class CommandManager extends \TYPO3\CMS\Extbase\Mvc\Cli\CommandManager
      */
     public function getShortestIdentifierForCommand(Command $command)
     {
-        if ($command->getCommandIdentifier() === 'extbase:help:autocomplete') {
+        if ($command->getCommandIdentifier() === 'typo3_console:help:help') {
+            return 'help';
+        }
+        if ($command->getCommandIdentifier() === 'typo3_console:help:autocomplete') {
             return 'autocomplete';
         }
         return parent::getShortestIdentifierForCommand($command);
@@ -85,6 +94,9 @@ class CommandManager extends \TYPO3\CMS\Extbase\Mvc\Cli\CommandManager
         if ($this->availableCommands === null) {
             $commandControllerRegistry = & $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'];
             if (!empty($commandControllerRegistry) && is_array($commandControllerRegistry)) {
+                $commandControllerRegistry = array_filter($commandControllerRegistry, function ($value) {
+                    return !in_array($value, [ExtensionCommandController::class, HelpCommandController::class], true);
+                });
                 $commandControllerRegistry = array_merge($commandControllerRegistry, $this->commandControllers);
             } else {
                 $commandControllerRegistry = $this->commandControllers;

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -1,6 +1,7 @@
 <?php
 return [
     'controllers' => [
+        \Helhum\Typo3Console\Command\HelpCommandController::class,
         \Helhum\Typo3Console\Command\CacheCommandController::class,
         \Helhum\Typo3Console\Command\BackendCommandController::class,
         \Helhum\Typo3Console\Command\SchedulerCommandController::class,
@@ -10,6 +11,7 @@ return [
         \Helhum\Typo3Console\Command\DatabaseCommandController::class,
         \Helhum\Typo3Console\Command\ConfigurationCommandController::class,
         \Helhum\Typo3Console\Command\FrontendCommandController::class,
+        \Helhum\Typo3Console\Command\ExtensionCommandController::class,
     ],
     'runLevels' => [
         'typo3_console:install:databasedata' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,


### PR DESCRIPTION
The cleanest way to remove TYPO3 core command controllers
is to remove them form the registry and add them to our own registry.

The we can also remove hard forcing class aliases.