### PR TITLE
	Cleanup command definition and CGL 

### DIFF
--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -22,8 +22,6 @@ return [
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
-        'typo3_console:extension:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
-        'typo3_console:extension:removeinactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
     ],
     'bootingSteps' => [
         'typo3_console:install:databasedata' => ['helhum.typo3console:database'],

--- a/Resources/Private/ExtensionArtifacts/ext_emconf.php
+++ b/Resources/Private/ExtensionArtifacts/ext_emconf.php
@@ -12,17 +12,13 @@ $EM_CONF[$_EXTKEY] = [
   'author_email' => 'info@helhum.io',
   'author_company' => 'helhum.io',
   'version' => '4.2.1',
-  'constraints' =>
-  [
-    'depends' =>
-    [
+  'constraints' => [
+    'depends' => [
       'typo3' => '7.6.0-8.6.99',
     ],
-    'conflicts' =>
-    [
+    'conflicts' => [
     ],
-    'suggests' =>
-    [
+    'suggests' => [
     ],
   ],
 ];

--- a/Tests/Functional/Fixtures/ext_test/ext_emconf.php
+++ b/Tests/Functional/Fixtures/ext_test/ext_emconf.php
@@ -12,17 +12,13 @@ $EM_CONF[$_EXTKEY] = [
   'author_email' => 'info@helhum.io',
   'author_company' => 'helhum.io',
   'version' => '0.1.0',
-  'constraints' =>
-  [
-    'depends' =>
-    [
+  'constraints' => [
+    'depends' => [
       'typo3' => '4.5.0-',
     ],
-    'conflicts' =>
-    [
+    'conflicts' => [
     ],
-    'suggests' =>
-    [
+    'suggests' => [
     ],
   ],
 ];


### PR DESCRIPTION
Command definition of extension:removeinactive is wrong
and effectively uses full RunLevel. This is fine
but we can then just skip the extra definition