### PR TITLE
Skip user authentication for extension:setupactive as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,9 @@ script:
   - test $(typo3cms database:export --exclude-tables sys_log | grep "CREATE TABLE" | grep -c sys_log) -eq 0
   - echo "SELECT username from be_users where admin=1;" | typo3cms database:import
   - echo "DROP DATABASE travis_test;" | typo3cms database:import
-  - echo "CREATE DATABASE travis_test;" | mysql -uroot && cat travis_test.sql | typo3cms database:import
+  - echo "CREATE DATABASE travis_test;" | mysql -uroot
   - typo3cms database:updateschema "*" --verbose
+  - typo3cms database:import < travis_test.sql
   - typo3cms frontend:request / > /dev/null
   - typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null
   - typo3cms configuration:show BE/installToolPassword
@@ -133,6 +134,9 @@ script:
   - typo3cms extension:activate ext_test && typo3cms cache:flush && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:activate core && typo3cms database:updateschema | grep 'No schema updates were performed'
   - typo3cms extension:setup core && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'
+  - echo "DROP DATABASE travis_test;" | typo3cms database:import
+  - echo "CREATE DATABASE travis_test;" | mysql -uroot
   - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'
   - if typo3cms extension:list --raw | grep dbal; then typo3cms extension:activate adodb,dbal && typo3cms database:updateschema | grep 'No schema updates were performed'; fi
   - typo3cms extension:removeinactive --force | grep 'The following directories have been removed'

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -22,9 +22,14 @@ return [
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        'typo3_console:extension:setupactive' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
     ],
     'bootingSteps' => [
         'typo3_console:install:databasedata' => ['helhum.typo3console:database'],
+        'typo3_console:extension:setupactive' => [
+            'helhum.typo3console:database',
+            'helhum.typo3console:persistence',
+        ],
         'typo3_console:install:defaultconfiguration' => ['helhum.typo3console:database'],
         'typo3_console:cache:flush' => ['helhum.typo3console:database'],
         'typo3_console:database:updateschema' => [


### PR DESCRIPTION
extension:setupactive also updates the db schema and is equally useful
to be executed with no database tables present.

This change also adds some checks to prove that both commands are
now executing successfully with an empty database