### PR TITLE
Stabilize Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,17 +23,14 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
 
 init:
-  - SET PHP=1
   - SET PATH=c:\php;%PATH%
   - SET COMPOSER_NO_INTERACTION=1
-  - SET TYPO3_PATH_WEB=c:\t3c\.Build\Web
 
 install:
-  - echo %TYPO3_PATH_WEB%
   - echo %COMPOSER_NO_INTERACTION%
-  - echo %PATH%
-  - echo %PHP%
+  - SET PHP=1
   - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+  - echo %PHP%
   - cd c:\php
   - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-nts-Win32-VC14-x86.zip
   - IF %PHP%==1 7z x php-%PHP_VERSION%-nts-Win32-VC14-x86.zip -y >nul
@@ -55,6 +52,8 @@ install:
 test_script:
   - cd c:\t3c
   - .Build\bin\phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/
+  - SET TYPO3_PATH_WEB=c:\t3c\.Build\Web
+  - echo %TYPO3_PATH_WEB%
   - php Scripts/typo3cms
   - php Scripts/typo3cms install:setup --non-interactive --database-user-name="root" --database-user-password="Password12!" --database-host-name="localhost" --database-port="3306" --database-name="appveyor_test" --admin-user-name="admin" --admin-password="password" --site-name="Appveyor Install" --site-setup-type="createsite"
 #  - echo 'select uid,title from pages limit 1' | typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,10 @@ init:
   - SET TYPO3_PATH_WEB=c:\t3c\.Build\Web
 
 install:
+  - echo %TYPO3_PATH_WEB%
+  - echo %COMPOSER_NO_INTERACTION%
+  - echo %PATH%
+  - echo %PHP%
   - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
   - cd c:\php
   - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-nts-Win32-VC14-x86.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,6 @@ services:
   - mysql
 
 environment:
-  COMPOSER_NO_INTERACTION: 1
-  PHP: 1
-  TYPO3_PATH_WEB: 'c:\t3c\.Build\Web'
-
   matrix:
     - TYPO3_VERSION: '~8.6'
       PHP_VERSION: '7.1.1'
@@ -27,7 +23,10 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
 
 init:
+  - SET PHP=1
   - SET PATH=c:\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET TYPO3_PATH_WEB=c:\t3c\.Build\Web
 
 install:
   - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)


### PR DESCRIPTION
It seems that in some cases the env vars are not correctly
populated to the scripts, so we explicitly set them
before executing them.