### PR TITLE
[TASK] Mention command to require TYPO3 core extensions

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -96,6 +96,12 @@ class InstallCommandController extends CommandController
      * - All core extensions which are provided with the <code>--framework-extensions</code> argument.
      * - In composer mode all composer dependencies to TYPO3 framework extensions are detected and activated by default.
      *
+     * To require TYPO3 core extensions use the following command:
+     *
+     * <code>composer require typo3/cms-foo "*"</code>
+     *
+     * This updates your composer.json and composer.lock without any other changes.
+     *
      * <b>Example:</b> <code>typo3cms install:generatepackagestates</code>
      *
      * @param array $frameworkExtensions TYPO3 system extensions that should be marked as active. Extension keys separated by comma.

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2017-02-14 21:09:18
+The following reference was automatically generated from code on 2017-03-08 16:00:00
 
 
 .. _`Command Reference: typo3_console`:
@@ -801,6 +801,12 @@ Marks the following extensions as active:
 - All core extensions that are required (or part of minimal usable system)
 - All core extensions which are provided with the ``--framework-extensions`` argument.
 - In composer mode all composer dependencies to TYPO3 framework extensions are detected and activated by default.
+
+To require TYPO3 core extensions use the following command:
+
+``composer require typo3/cms-foo "*"``
+
+This updates your composer.json and composer.lock without any other changes.
 
 **Example:** ``typo3cms install:generatepackagestates``
 


### PR DESCRIPTION
This is essential when using `install:generatepackagestates`.