### PR TITLE
[BUGFIX] Make compatible with TYPO3 8LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,17 @@ matrix:
     - php: 7.0
       env: TYPO3_VERSION=^7.6
     - php: 7.0
-      env: TYPO3_VERSION=~8.3.0
+      env: TYPO3_VERSION=^8.7
     - php: 7.0
-      env: TYPO3_VERSION=~8.4.0
-    - php: 7.0
-      env: TYPO3_VERSION=~8.5.0
-    - php: 7.0
-      env: TYPO3_VERSION=~8.6.0
-    - php: 7.0
-      env: TYPO3_VERSION="dev-master as 8.6.0"
+      env: TYPO3_VERSION="dev-master as 8.7.0"
     - php: 7.1
       env: TYPO3_VERSION=^7.6
     - php: 7.1
-      env: TYPO3_VERSION=^8
+      env: TYPO3_VERSION=^8.7
     - php: 7.1
-      env: TYPO3_VERSION="dev-master as 8.6.0"
+      env: TYPO3_VERSION="dev-master as 8.7.0"
   allow_failures:
-    - env: TYPO3_VERSION="dev-master as 8.6.0"
+    - env: TYPO3_VERSION="dev-master as 8.7.0"
 
 cache:
   directories:

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -204,7 +204,7 @@ class InstallCommandController extends CommandController
      */
     public function databaseConnectCommand($databaseUserName = '', $databaseUserPassword = '', $databaseHostName = 'localhost', $databasePort = '3306', $databaseSocket = '')
     {
-        $this->executeActionWithArguments('databaseConnect', ['host' => $databaseHostName, 'port' => $databasePort, 'username' => $databaseUserName, 'password' => $databaseUserPassword, 'socket' => $databaseSocket]);
+        $this->executeActionWithArguments('databaseConnect', ['host' => $databaseHostName, 'port' => $databasePort, 'username' => $databaseUserName, 'password' => $databaseUserPassword, 'socket' => $databaseSocket, 'driver' => 'mysqli']);
     }
 
     /**

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -16,15 +16,12 @@ namespace Helhum\Typo3Console\Install;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\CommandManager;
 use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Cli\CommandArgumentDefinition;
 use TYPO3\CMS\Extbase\Mvc\Controller\Argument;
 use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
 use TYPO3\CMS\Extbase\Mvc\Exception\InvalidArgumentTypeException;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Reflection\ReflectionService;
-use TYPO3\CMS\Install\Controller\Exception\RedirectException;
-use TYPO3\CMS\Install\Service\SilentConfigurationUpgradeService;
 use TYPO3\CMS\Install\Status\StatusInterface;
 
 /**
@@ -118,7 +115,6 @@ class CliSetupRequestHandler
 
         foreach ($this->installationActions as $actionName) {
             $this->dispatchAction($actionName);
-            $this->executeSilentConfigurationUpgradesIfNeeded();
         }
     }
 
@@ -273,39 +269,6 @@ class CliSetupRequestHandler
         }
 
         return $arguments;
-    }
-
-    /**
-     * Call silent upgrade class, redirect to self if configuration was changed.
-     *
-     * @throws RedirectException
-     * @return void
-     */
-    protected function executeSilentConfigurationUpgradesIfNeeded()
-    {
-        $upgradeService = $this->objectManager->get(SilentConfigurationUpgradeService::class);
-        $count = 0;
-        do {
-            try {
-                $count++;
-                $upgradeService->execute();
-                $redirect = false;
-            } catch (RedirectException $e) {
-                $redirect = true;
-                $this->reloadConfiguration();
-                if ($count > 20) {
-                    throw $e;
-                }
-            }
-        } while ($redirect === true);
-    }
-
-    /**
-     * Fetch the new configuration and expose it to the global array
-     */
-    protected function reloadConfiguration()
-    {
-        GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ConfigurationManager::class)->exportConfiguration();
     }
 
     // Logging and output related stuff

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -157,7 +157,7 @@ class CommandDispatcher
             }
         }
 
-        $process = $processBuilder->getProcess();
+        $process = $processBuilder->setTimeout(null)->getProcess();
         $process->run();
         $output = str_replace("\r\n", "\n", trim($process->getOutput()));
 

--- a/composer.json
+++ b/composer.json
@@ -26,21 +26,21 @@
         "php": ">=5.5.0",
         "helhum/typo3-console-plugin": "^1.5.0",
 
-        "typo3/cms-backend": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-core": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-extbase": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-extensionmanager": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-fluid": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-install": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-saltedpasswords": "^7.6 || >=8.3.0 <8.7",
-        "typo3/cms-scheduler": "^7.6 || >=8.3.0 <8.7",
+        "typo3/cms-backend": "^7.6 || ^8.7",
+        "typo3/cms-core": "^7.6 || ^8.7",
+        "typo3/cms-extbase": "^7.6 || ^8.7",
+        "typo3/cms-extensionmanager": "^7.6 || ^8.7",
+        "typo3/cms-fluid": "^7.6 || ^8.7",
+        "typo3/cms-install": "^7.6 || ^8.7",
+        "typo3/cms-saltedpasswords": "^7.6 || ^8.7",
+        "typo3/cms-scheduler": "^7.6 || ^8.7",
 
         "symfony/console": "^2.7 || ^3.0",
         "symfony/process": "^2.7 || ^3.0"
     },
     "require-dev": {
         "typo3-console/create-reference-command": "1.0.*@dev",
-        "typo3/cms": "^8.6",
+        "typo3/cms": "^8.7",
         "nimut/testing-framework": "^1.0",
         "mikey179/vfsStream": "~1.6.0",
         "phpunit/phpunit": "~4.8.0"


### PR DESCRIPTION
Due to some changes in the install process it has become
apparent, that we need to execute the silent configuration
upgrade more often, likely directly after an action was executed.

For that we move this into the child process.

This makes the install work again, but with an error message, that
hints to to the second required fix, which is providing the database
driver.

For now we hard code it to mysqli and make it available as option
in later releases.

Fixes: #448
Closes: #449