### PR TITLE
[BUGFIX] Do not write extConf if present already

### DIFF
--- a/Classes/Extension/ExtensionSetup.php
+++ b/Classes/Extension/ExtensionSetup.php
@@ -66,7 +66,9 @@ class ExtensionSetup
         foreach ($packages as $package) {
             $this->extensionFactory->getExtensionStructure($package)->fix();
             $this->callInstaller('importInitialFiles', [PathUtility::stripPathSitePrefix($package->getPackagePath()), $package->getPackageKey()]);
-            $this->callInstaller('saveDefaultConfiguration', [$package->getPackageKey()]);
+            if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$package->getPackageKey()])) {
+                $this->callInstaller('saveDefaultConfiguration', [$package->getPackageKey()]);
+            }
         }
 
         $this->schemaService->updateSchema(SchemaUpdateType::expandSchemaUpdateTypes(['safe']));


### PR DESCRIPTION
When using extension:setupactive there are several steps
performed for each extension. One step is writing the
default extension configuration to LocalConfiguration.php
This is done regardless there is a configuration present already.

To avoid having the need to have write access to LocalConfiguration.php
in production, this step is now skipped when extConf for the
extension is already present for extensions that are set up
using extension:setupactive