### PR TITLE
[BUGFIX] Do write default extConf if no extConf is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ script:
   - typo3cms help && [ ! -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
   - typo3cms install:setup --non-interactive --database-user-name="root" --database-host-name="localhost" --database-port="3306" --database-name="travis_test" --admin-user-name="admin" --admin-password="password" --site-name="Travis Install" --site-setup-type="createsite"
   - echo 'select uid,title from pages limit 1' | typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home
+  - chmod ugo-w $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php && typo3cms extension:setupactive && chmod ug+w $TYPO3_PATH_WEB/typo3conf/LocalConfiguration.php
   - typo3cms help
   - typo3cms help:autocomplete
   - typo3cms help:autocomplete bash

--- a/Classes/Extension/ExtensionSetup.php
+++ b/Classes/Extension/ExtensionSetup.php
@@ -66,7 +66,9 @@ class ExtensionSetup
         foreach ($packages as $package) {
             $this->extensionFactory->getExtensionStructure($package)->fix();
             $this->callInstaller('importInitialFiles', [PathUtility::stripPathSitePrefix($package->getPackagePath()), $package->getPackageKey()]);
-            if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$package->getPackageKey()])) {
+            if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$package->getPackageKey()])
+                && @is_file($package->getPackagePath() . 'ext_conf_template.txt')
+            ) {
                 $this->callInstaller('saveDefaultConfiguration', [$package->getPackageKey()]);
             }
         }

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -116,6 +116,9 @@ class CliSetupRequestHandler
         foreach ($this->installationActions as $actionName) {
             $this->dispatchAction($actionName);
         }
+        // The TYPO3 installation process does not take care of setting up all extensions properly,
+        // so we do it manually here
+        $this->commandDispatcher->executeCommand('extension:setupactive');
     }
 
     /**


### PR DESCRIPTION
We must not only check if the configuration is present, but
also need to check whether there is a ext_conf_template.txt
file at all.

Besides that, we must ensure that after installation all extensions
have been set up properly.

Add travis tests to verify both.