### PR TITLE
[BUGFIX] Enable setup with existing LocalConfiguration.php

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -51,6 +51,7 @@ class InstallCommandController extends CommandController
      *
      * @param bool $nonInteractive If specified, optional arguments are not requested, but default values are assumed.
      * @param bool $force Force installation of TYPO3, even if <code>LocalConfiguration.php</code> file already exists.
+     * @param bool $skipIntegrityCheck Skip the checking for clean state before executing setup. This allows a pre-defined <code>LocalConfiguration.php</code> to be present. Handle with care. It might lead to unexpected or broken installation results.
      * @param string $databaseUserName User name for database server
      * @param string $databaseUserPassword User password for database server
      * @param string $databaseHostName Host name of database server
@@ -66,6 +67,7 @@ class InstallCommandController extends CommandController
     public function setupCommand(
         $nonInteractive = false,
         $force = false,
+        $skipIntegrityCheck = false,
         $databaseUserName = '',
         $databaseUserPassword = '',
         $databaseHostName = '',
@@ -81,7 +83,9 @@ class InstallCommandController extends CommandController
         $this->outputLine();
         $this->outputLine('<i>Welcome to the TYPO3 console installer!</i>');
 
-        $this->ensureInstallationPossible($nonInteractive, $force);
+        if (!$skipIntegrityCheck) {
+            $this->ensureInstallationPossible($nonInteractive, $force);
+        }
 
         $this->cliSetupRequestHandler->setup(!$nonInteractive, $this->request->getArguments());
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2017-03-08 16:00:00
+The following reference was automatically generated from code on 2017-04-06 15:25:57
 
 
 .. _`Command Reference: typo3_console`:
@@ -845,6 +845,8 @@ Options
   If specified, optional arguments are not requested, but default values are assumed.
 ``--force``
   Force installation of TYPO3, even if ``LocalConfiguration.php`` file already exists.
+``--skip-integrity-check``
+  Skip the checking for clean state before executing setup. This allows a pre-defined ``LocalConfiguration.php`` to be present. Handle with care. It might lead to unexpected or broken installation results.
 ``--database-user-name``
   User name for database server
 ``--database-user-password``


### PR DESCRIPTION
Although TYPO3 is not built for being set up with a LocalConfiguration.php
to be present, it might be useful in certain (first) deployment scenarios.

Therefore we allow the installation, although it might fail with invalid
LocalConfiguration.php files