### PR TITLE
[BUGFIX] Always emit extension activation signal

### DIFF
--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -98,7 +98,7 @@ class ExtensionCommandController extends CommandController
         }
 
         if (!empty($extensionsToSetUp)) {
-            $this->setupExtensions($extensionsToSetUp, $activatedExtensions);
+            $this->setupExtensions($extensionsToSetUp);
         }
     }
 
@@ -157,16 +157,15 @@ class ExtensionCommandController extends CommandController
      * To do so, we avoid buggy TYPO3 API and use our own instead.
      *
      * @param PackageInterface[] $packages
-     * @param array $activatedExtensionKeys
      */
-    private function setupExtensions(array $packages, array $activatedExtensionKeys = [])
+    private function setupExtensions(array $packages)
     {
         $extensionSetup = new ExtensionSetup(
             new ExtensionFactory($this->packageManager),
             $this->extensionInstaller
         );
 
-        $extensionSetup->setupExtensions($packages, $activatedExtensionKeys);
+        $extensionSetup->setupExtensions($packages);
         $extensionKeysAsString = implode('", "', array_map(function (PackageInterface $package) {
             return $package->getPackageKey();
         }, $packages));

--- a/Classes/Extension/ExtensionSetup.php
+++ b/Classes/Extension/ExtensionSetup.php
@@ -59,9 +59,8 @@ class ExtensionSetup
      * This might be removed, once the bug is fixed in TYPO3.
      *
      * @param PackageInterface[] $packages
-     * @param array $activatedExtensionKeys
      */
-    public function setupExtensions(array $packages, array $activatedExtensionKeys = [])
+    public function setupExtensions(array $packages)
     {
         foreach ($packages as $package) {
             $this->extensionFactory->getExtensionStructure($package)->fix();
@@ -80,9 +79,7 @@ class ExtensionSetup
             $extensionKey = $package->getPackageKey();
             $this->callInstaller('importStaticSqlFile', [$relativeExtensionPath]);
             $this->callInstaller('importT3DFile', [$relativeExtensionPath]);
-            if (in_array($extensionKey, $activatedExtensionKeys, true)) {
-                $this->callInstaller('emitAfterExtensionInstallSignal', [$extensionKey]);
-            }
+            $this->callInstaller('emitAfterExtensionInstallSignal', [$extensionKey]);
         }
     }
 


### PR DESCRIPTION
The event subscribers' code must be idempotent, therefore
it save safe to emit this event every time setup is called

Fixes #444