### PR TITLE
[FEATURE] Upgrade Automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ matrix:
       env: TYPO3_VERSION=^7.6
     - php: 7.0
       env: TYPO3_VERSION=^7.6
+    - php: 7.1
+      env: TYPO3_VERSION=^7.6
     - php: 7.0
+      env: TYPO3_VERSION=^8.7
+    - php: 7.1
       env: TYPO3_VERSION=^8.7
     - php: 7.0
       env: TYPO3_VERSION="dev-master as 8.7.0"
-    - php: 7.1
-      env: TYPO3_VERSION=^7.6
-    - php: 7.1
-      env: TYPO3_VERSION=^8.7
     - php: 7.1
       env: TYPO3_VERSION="dev-master as 8.7.0"
   allow_failures:

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -90,7 +90,7 @@ class InstallCommandController extends CommandController
         $this->cliSetupRequestHandler->setup(!$nonInteractive, $this->request->getArguments());
 
         $this->outputLine();
-        $this->outputLine('Successfully installed TYPO3 CMS!');
+        $this->outputLine('<i>Successfully installed TYPO3 CMS!</i>');
     }
 
     /**

--- a/Classes/Command/UpgradeCommandController.php
+++ b/Classes/Command/UpgradeCommandController.php
@@ -1,0 +1,114 @@
+<?php
+namespace Helhum\Typo3Console\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Install\Upgrade\UpgradeHandling;
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardListRenderer;
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardResultRenderer;
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Controller\CommandController;
+
+class UpgradeCommandController extends CommandController
+{
+    /**
+     * @var UpgradeHandling
+     */
+    private $upgradeHandling;
+
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    /**
+     * @param UpgradeHandling|null $upgradeHandling
+     * @param CommandDispatcher|null $commandDispatcher
+     */
+    public function __construct(
+        UpgradeHandling $upgradeHandling = null,
+        CommandDispatcher $commandDispatcher = null
+    ) {
+        $this->upgradeHandling = $upgradeHandling ?: new UpgradeHandling();
+        $this->commandDispatcher = $commandDispatcher ?: CommandDispatcher::createFromCommandRun();
+    }
+
+    /**
+     * List upgrade wizards
+     *
+     * @param bool $verbose If set, a more verbose description for each wizard is shown, if not set only the title is shown
+     * @param bool $all If set, all wizards will be listed, even the once marked as ready or done
+     */
+    public function listCommand($verbose = false, $all = false)
+    {
+        $wizards = $this->upgradeHandling->executeInSubProcess('listWizards');
+
+        $listRenderer = new UpgradeWizardListRenderer();
+        $this->outputLine('<comment>Wizards scheduled for execution:</comment>');
+        $listRenderer->render($wizards['scheduled'], $this->output, $verbose);
+
+        if ($all) {
+            $this->outputLine(PHP_EOL . '<comment>Wizards marked as done:</comment>');
+            $listRenderer->render($wizards['done'], $this->output, $verbose);
+        }
+    }
+
+    /**
+     * Execute a single upgrade wizard
+     *
+     * @param string $identifier Identifier of the wizard that should be executed
+     * @param array $arguments Arguments for the wizard prefixed with the identifier, e.g. <code>compatibility7Extension[install]=0</code>
+     * @param bool $force Force execution, even if the wizard has been marked as done
+     */
+    public function wizardCommand($identifier, array $arguments = [], $force = false)
+    {
+        $result = $this->upgradeHandling->executeInSubProcess('executeWizard', [$identifier, $arguments, $force]);
+        (new UpgradeWizardResultRenderer())->render([$identifier => $result], $this->output);
+    }
+
+    /**
+     * Execute all upgrade wizards that are scheduled for execution
+     *
+     * @param array $arguments Arguments for the wizard prefixed with the identifier, e.g. <code>compatibility7Extension[install]=0</code>; multiple arguments separated with comma
+     * @param bool $verbose If set, output of the wizards will be shown, including all SQL Queries that were executed
+     */
+    public function allCommand(array $arguments = [], $verbose = false)
+    {
+        $this->outputLine('<i>Initiating TYPO3 upgrade</i>' . PHP_EOL);
+
+        $results = $this->upgradeHandling->executeAll($arguments, $this->output);
+
+        $this->outputLine(PHP_EOL . PHP_EOL . '<i>Successfully upgraded TYPO3 to version %s</i>', [TYPO3_version]);
+
+        if ($verbose) {
+            $this->outputLine();
+            $this->outputLine('<comment>Upgrade report:</comment>');
+            (new UpgradeWizardResultRenderer())->render($results, $this->output);
+        }
+    }
+
+    /**
+     * This is where the hard work happens in a fully bootstrapped TYPO3
+     * It will be called as sub process
+     *
+     * @param string $command
+     * @param string $arguments Serialized arguments
+     * @internal
+     */
+    public function subProcessCommand($command, $arguments)
+    {
+        $arguments = unserialize($arguments);
+        $result = call_user_func_array([$this->upgradeHandling, $command], $arguments);
+        $this->output(serialize($result));
+    }
+}

--- a/Classes/Composer/InstallerScript/GeneratePackageStates.php
+++ b/Classes/Composer/InstallerScript/GeneratePackageStates.php
@@ -71,9 +71,9 @@ class GeneratePackageStates implements InstallerScriptInterface
             'frameworkExtensions' => (string)getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS'),
         ];
         if (getenv('TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS')) {
-            $commandOptions['activateDefault'] = null;
+            $commandOptions['activateDefault'] = true;
         }
-        if ($event->isDevMode()) {
+        if ($event->isDevMode() && getenv('TYPO3_EXCLUDED_EXTENSIONS')) {
             $commandOptions['excludedExtensions'] = (string)getenv('TYPO3_EXCLUDED_EXTENSIONS');
         }
         $output = $commandDispatcher->executeCommand('install:generatepackagestates', $commandOptions);

--- a/Classes/Install/InstallStepActionExecutor.php
+++ b/Classes/Install/InstallStepActionExecutor.php
@@ -37,6 +37,7 @@ class InstallStepActionExecutor
 
     /**
      * @param ObjectManager $objectManager
+     * @param SilentConfigurationUpgrade $silentConfigurationUpgrade
      */
     public function __construct(ObjectManager $objectManager, SilentConfigurationUpgrade $silentConfigurationUpgrade)
     {

--- a/Classes/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Install/Upgrade/UpgradeHandling.php
@@ -1,0 +1,233 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Core\ConsoleBootstrap;
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Helhum\Typo3Console\Service\Configuration\ConfigurationService;
+use TYPO3\CMS\Install\Updates\DatabaseCharsetUpdate;
+
+/**
+ * Executes a single upgrade wizard
+ * Holds the information on possible user interactions
+ */
+class UpgradeHandling
+{
+    /**
+     * @var UpgradeWizardExecutor
+     */
+    private $executor;
+
+    /**
+     * @var SilentConfigurationUpgrade
+     */
+    private $silentConfigurationUpgrade;
+
+    /**
+     * @var CommandDispatcher
+     */
+    private $commandDispatcher;
+
+    /**
+     * @var UpgradeWizardList
+     */
+    private $upgradeWizardList;
+
+    /**
+     * @var ConfigurationService|null
+     */
+    private $configurationService;
+
+    /**
+     * Flag for same process
+     *
+     * @var bool
+     */
+    private $initialUpgradeDone = false;
+
+    /**
+     * Wizards that have a user interaction with resulting argument
+     *
+     * @var array
+     */
+    private static $wizardsWithArguments = [
+        'DbalAndAdodbExtractionUpdate' => [['name' => 'install', 'type' => 'bool', 'default' => '0']],
+        'compatibility7Extension' => [['name' => 'install', 'type' => 'bool', 'default' => '0']],
+        'rtehtmlareaExtension' => [['name' => 'install', 'type' => 'bool', 'default' => '0']],
+    ];
+    /**
+     * @var UpgradeWizardFactory|null
+     */
+    private $factory;
+
+    /**
+     * @param UpgradeWizardFactory|null $factory
+     * @param UpgradeWizardExecutor $executor
+     * @param UpgradeWizardList|null $upgradeWizardList
+     * @param SilentConfigurationUpgrade|null $silentConfigurationUpgrade
+     * @param CommandDispatcher|null $commandDispatcher
+     * @param ConfigurationService|null $configurationService
+     */
+    public function __construct(
+        UpgradeWizardFactory $factory = null,
+        UpgradeWizardExecutor $executor = null,
+        UpgradeWizardList $upgradeWizardList = null,
+        SilentConfigurationUpgrade $silentConfigurationUpgrade = null,
+        CommandDispatcher $commandDispatcher = null,
+        ConfigurationService $configurationService = null
+    ) {
+        $this->factory = new UpgradeWizardFactory();
+        $this->executor = $executor ?: new UpgradeWizardExecutor($this->factory);
+        $this->upgradeWizardList = $upgradeWizardList ?: new UpgradeWizardList();
+        $this->silentConfigurationUpgrade = $silentConfigurationUpgrade ?: new SilentConfigurationUpgrade();
+        $this->commandDispatcher = $commandDispatcher ?: CommandDispatcher::createFromCommandRun();
+        $this->configurationService = $configurationService ?: new ConfigurationService();
+    }
+
+    /**
+     * @param string $identifier
+     * @param array $rawArguments
+     * @param bool $force
+     * @return UpgradeWizardResult
+     */
+    public function executeWizard($identifier, array $rawArguments = [], $force = false)
+    {
+        return $this->executor->executeWizard($identifier, $rawArguments, $force);
+    }
+
+    /**
+     * @param array $arguments
+     * @param ConsoleOutput|null $consoleOutput
+     * @return array
+     */
+    public function executeAll(array $arguments, ConsoleOutput $consoleOutput = null)
+    {
+        if ($consoleOutput) {
+            $consoleOutput->progressStart(rand(6, 9));
+            $consoleOutput->progressAdvance();
+        }
+
+        $wizards = $this->executeInSubProcess('listWizards');
+
+        if ($consoleOutput) {
+            $consoleOutput->progressStart(count($wizards['scheduled']) + 2);
+        }
+
+        $results = [];
+        if (!empty($wizards['scheduled'])) {
+            foreach ($wizards['scheduled'] as $identifier => $_) {
+                if ($consoleOutput) {
+                    $consoleOutput->progressAdvance();
+                }
+                $shortIdentifier = str_replace('TYPO3\\CMS\\Install\\Updates\\', '', $identifier);
+                if ($consoleOutput && isset(self::$wizardsWithArguments[$shortIdentifier])
+                ) {
+                    foreach (self::$wizardsWithArguments[$shortIdentifier] as $argumentDefinition) {
+                        $argumentName = $argumentDefinition['name'];
+                        $argumentDefault = $argumentDefinition['default'];
+                        if ($this->wizardHasArgument($shortIdentifier, $argumentName, $arguments)) {
+                            continue;
+                        }
+                        // In composer mode, skip all install extension wizards!
+                        if (ConsoleBootstrap::usesComposerClassLoading()) {
+                            $arguments[] = sprintf('%s[%s]=%s', $shortIdentifier, $argumentName, $argumentDefault);
+                        } elseif ($argumentDefinition['type'] === 'bool') {
+                            $wizard = $this->factory->create($shortIdentifier);
+                            $consoleOutput->outputLine(PHP_EOL . PHP_EOL . '<info>' . $wizard->getTitle() . '</info>' . PHP_EOL);
+                            $consoleOutput->outputLine(implode(PHP_EOL, array_filter(array_map('trim', explode(chr(10), html_entity_decode(strip_tags($wizard->getUserInput(''))))))));
+                            $consoleOutput->outputLine();
+                            $arguments[] = sprintf(
+                                '%s[%s]=%s',
+                                    $shortIdentifier,
+                                    $argumentName,
+                                    (string)(int)$consoleOutput->askConfirmation('<comment>Install (y/N)</comment> ', $argumentDefault)
+                            );
+                        }
+                    }
+                }
+                $results[$identifier] = $this->executeInSubProcess('executeWizard', [$identifier, $arguments]);
+            }
+        }
+
+        if ($consoleOutput) {
+            $consoleOutput->progressAdvance();
+        }
+
+        $this->commandDispatcher->executeCommand('database:updateschema');
+
+        if ($consoleOutput) {
+            $consoleOutput->progressFinish();
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $argumentName
+     * @param array $arguments
+     * @return bool
+     */
+    private function wizardHasArgument($identifier, $argumentName, array $arguments)
+    {
+        if (isset(self::$wizardsWithArguments[$identifier])) {
+            foreach ($arguments as $argument) {
+                if (strpos($argument, sprintf('%s[%s]', $identifier, $argumentName)) !== false) {
+                    return true;
+                }
+                if (strpos($argument, '[') === false && strpos($argument, $argumentName) !== false) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function listWizards()
+    {
+        return [
+            'scheduled' => $this->upgradeWizardList->listWizards(),
+            'done' => $this->upgradeWizardList->listWizards(true),
+        ];
+    }
+
+    /**
+     * Execute the command in a sub process,
+     * but execute some automated migration steps beforehand
+     *
+     * @param string $command
+     * @param array $arguments
+     * @return mixed
+     */
+    public function executeInSubProcess($command, array $arguments = [])
+    {
+        $this->ensureUpgradeIsPossible();
+        return @unserialize($this->commandDispatcher->executeCommand('upgrade:subprocess', ['command' => $command, 'arguments' => serialize($arguments)]));
+    }
+
+    private function ensureUpgradeIsPossible()
+    {
+        if (!$this->initialUpgradeDone && !$this->configurationService->hasActive('EXTCONF/helhum-typo3-console/initialUpgradeDone')) {
+            $this->initialUpgradeDone = true;
+            $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', true);
+            $this->silentConfigurationUpgrade->executeSilentConfigurationUpgradesIfNeeded();
+            $this->commandDispatcher->executeCommand('upgrade:executewizard', ['identifier' => DatabaseCharsetUpdate::class]);
+            $this->commandDispatcher->executeCommand('database:updateschema');
+        }
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeWizardExecutor.php
+++ b/Classes/Install/Upgrade/UpgradeWizardExecutor.php
@@ -1,0 +1,95 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\DummyUpgradeWizard;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Executes a single upgrade wizard
+ * Holds the information on possible user interactions
+ */
+class UpgradeWizardExecutor
+{
+    /**
+     * @var UpgradeWizardFactory
+     */
+    private $factory;
+
+    public function __construct(UpgradeWizardFactory $factory = null)
+    {
+        $this->factory = $factory ?: new UpgradeWizardFactory();
+    }
+
+    /**
+     * @param string $identifier
+     * @param array $rawArguments
+     * @param bool $force
+     * @return UpgradeWizardResult
+     */
+    public function executeWizard($identifier, array $rawArguments = [], $force = false)
+    {
+        $upgradeWizard = $this->factory->create($identifier);
+
+        if ($force) {
+            $closure = \Closure::bind(function () use ($upgradeWizard) {
+                /** @var DummyUpgradeWizard $upgradeWizard here to avoid annoying (and wrong) protected method inspection in PHPStorm */
+                $upgradeWizard->markWizardAsDone(0);
+            }, null, get_class($upgradeWizard));
+            $closure();
+        }
+
+        if (!$upgradeWizard->shouldRenderWizard()) {
+            return new UpgradeWizardResult(false);
+        }
+
+        // OMG really?
+        GeneralUtility::_GETset(
+            [
+                'values' => [
+                    $identifier => $this->processRawArguments($identifier, $rawArguments),
+                    'TYPO3\\CMS\\Install\\Updates\\' . $identifier => $this->processRawArguments($identifier, $rawArguments),
+                ],
+            ],
+            'install'
+        );
+
+        $dbQueries = [];
+        $message = '';
+        $hasPerformed = $upgradeWizard->performUpdate($dbQueries, $message);
+
+        return new UpgradeWizardResult($hasPerformed, $dbQueries, [$message]);
+    }
+
+    /**
+     * @param string $identifier
+     * @return bool
+     */
+    public function wizardNeedsExecution($identifier)
+    {
+        $upgradeWizard = $this->factory->create($identifier);
+        return $upgradeWizard->shouldRenderWizard();
+    }
+
+    private function processRawArguments($identifier, array $rawArguments = [])
+    {
+        $processedArguments = [];
+        foreach ($rawArguments as $argument) {
+            parse_str($argument, $processedArgument);
+            $processedArguments = array_replace_recursive($processedArguments, $processedArgument);
+        }
+        $argumentNamespace = str_replace('TYPO3\\CMS\\Install\\Updates\\', '', $identifier);
+        return isset($processedArguments[$argumentNamespace]) ? $processedArguments[$argumentNamespace] : $processedArguments;
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeWizardFactory.php
+++ b/Classes/Install/Upgrade/UpgradeWizardFactory.php
@@ -1,0 +1,68 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+/**
+ * Creates a single upgrade wizard
+ */
+class UpgradeWizardFactory
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var array
+     */
+    private $wizardRegistry;
+
+    /**
+     * @param ObjectManager $objectManager
+     * @param array $wizardRegistry
+     */
+    public function __construct(
+        ObjectManager $objectManager = null,
+        array $wizardRegistry = []
+    ) {
+        // @deprecated Object Manager can be removed, once TYPO3 7.6 support is removed
+        $this->objectManager = $objectManager ?: GeneralUtility::makeInstance(ObjectManager::class);
+        $this->wizardRegistry = $wizardRegistry ?: $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'];
+    }
+
+    /**
+     * Creates instance of an upgrade wizard
+     *
+     * @param string $identifier The identifier or class name of an upgrade wizard
+     * @return AbstractUpdate Newly instantiated upgrade wizard
+     */
+    public function create($identifier)
+    {
+        if (empty($className = $this->wizardRegistry[$identifier])
+            && empty($className = $this->wizardRegistry['TYPO3\\CMS\\Install\\Updates\\' . $identifier])
+            && !class_exists($className = $identifier)
+        ) {
+            throw new \RuntimeException(sprintf('Upgrade wizard "%s" not found', $identifier), 1491914890);
+        }
+        /** @var AbstractUpdate $upgradeWizard */
+        $upgradeWizard = $this->objectManager->get($className);
+        $upgradeWizard->setIdentifier($identifier);
+
+        return $upgradeWizard;
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeWizardList.php
+++ b/Classes/Install/Upgrade/UpgradeWizardList.php
@@ -1,0 +1,95 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Handle update wizards
+ */
+class UpgradeWizardList
+{
+    /**
+     * @var UpgradeWizardFactory
+     */
+    private $factory;
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    /**
+     * @var array
+     */
+    private $wizardRegistry;
+
+    /**
+     * @var array
+     */
+    private $listCache = [];
+
+    /**
+     * UpgradeWizardList constructor.
+     *
+     * @param UpgradeWizardFactory|null $factory
+     * @param Registry|null $registry
+     * @param array $wizardRegistry
+     */
+    public function __construct(
+        UpgradeWizardFactory $factory = null,
+        Registry $registry = null,
+        array $wizardRegistry = []
+    ) {
+        $this->factory = $factory ?: new UpgradeWizardFactory();
+        $this->registry = $registry ?: GeneralUtility::makeInstance(Registry::class);
+        $this->wizardRegistry = $wizardRegistry ?: $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'];
+    }
+
+    /**
+     * List available upgrade wizards
+     *
+     * @param bool $includeDone
+     * @return array
+     */
+    public function listWizards($includeDone = false)
+    {
+        if (empty($this->listCache)) {
+            $availableUpgradeWizards = [];
+            foreach ($this->wizardRegistry as $identifier => $className) {
+                $updateObject = $this->factory->create($identifier);
+                $availableUpgradeWizards[$identifier] = [
+                    'title' => $updateObject->getTitle(),
+                    'done' => false,
+                ];
+                $explanation = '';
+                if ($this->registry->get('installUpdate', $className, false)
+                    || !$updateObject->checkForUpdate($explanation)
+                ) {
+                    $availableUpgradeWizards[$identifier]['done'] = true;
+                }
+                $availableUpgradeWizards[$identifier]['explanation'] = html_entity_decode(strip_tags($explanation));
+            }
+            $this->listCache = $availableUpgradeWizards;
+        }
+
+        return array_filter(
+            $this->listCache,
+            function ($info) use ($includeDone) {
+                return $includeDone || !$info['done'];
+            }
+        );
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeWizardListRenderer.php
+++ b/Classes/Install/Upgrade/UpgradeWizardListRenderer.php
@@ -1,0 +1,61 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Symfony\Component\Console\Helper\TableSeparator;
+
+/**
+ * Renders a list of upgrade wizards
+ */
+class UpgradeWizardListRenderer
+{
+    /**
+     * Renders a table for upgrade wizards
+     *
+     * @param array $upgradeWizardList
+     * @param ConsoleOutput $output
+     * @param mixed $verbose
+     */
+    public function render(array $upgradeWizardList, ConsoleOutput $output, $verbose = false)
+    {
+        if (empty($upgradeWizardList)) {
+            $output->outputLine('<info>None</info>');
+            return;
+        }
+        $tableHeader = ['Identifier', 'Title'];
+        if ($verbose) {
+            $tableHeader = ['Identifier', 'Description'];
+        }
+
+        $tableRows = [];
+        foreach ($upgradeWizardList as $identifier => $info) {
+            $row = [
+                str_replace('TYPO3\\CMS\\Install\\Updates\\', '', $identifier),
+                wordwrap($info['title'], 40),
+            ];
+            if ($verbose) {
+                $row = [
+                    str_replace('TYPO3\\CMS\\Install\\Updates\\', '', $identifier),
+                    wordwrap($info['explanation'], 40),
+                ];
+            }
+            $tableRows[] = $row;
+            $tableRows[] = new TableSeparator();
+        }
+        array_pop($tableRows);
+
+        $output->outputTable($tableRows, $tableHeader);
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeWizardResult.php
+++ b/Classes/Install/Upgrade/UpgradeWizardResult.php
@@ -1,0 +1,63 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+class UpgradeWizardResult
+{
+    /**
+     * @var array
+     */
+    private $sqlQueries;
+
+    /**
+     * @var array
+     */
+    private $messages;
+
+    /**
+     * @var bool
+     */
+    private $hasPerformed;
+
+    public function __construct($hasPerformed, array $sqlQueries = [], array $messages = [])
+    {
+        $this->sqlQueries = $sqlQueries;
+        $this->messages = $messages;
+        $this->hasPerformed = $hasPerformed;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSqlQueries()
+    {
+        return $this->sqlQueries;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPerformed()
+    {
+        return $this->hasPerformed;
+    }
+}

--- a/Classes/Install/Upgrade/UpgradeWizardResultRenderer.php
+++ b/Classes/Install/Upgrade/UpgradeWizardResultRenderer.php
@@ -1,0 +1,56 @@
+<?php
+namespace Helhum\Typo3Console\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+
+/**
+ * Renders results of executed upgrade wizards
+ */
+class UpgradeWizardResultRenderer
+{
+    /**
+     * Renders a table for upgrade wizards
+     *
+     * @param UpgradeWizardResult[] $upgradeWizardResult
+     * @param ConsoleOutput $output
+     */
+    public function render(array $upgradeWizardResult, ConsoleOutput $output)
+    {
+        if (empty($upgradeWizardResult)) {
+            return;
+        }
+        foreach ($upgradeWizardResult as $identifier => $result) {
+            $identifier = str_replace('TYPO3\\CMS\\Install\\Updates\\', '', $identifier);
+            $output->outputLine();
+            if (!$result->hasPerformed()) {
+                $output->outputLine('<warning>Skipped upgrade wizard "%s" because it was not scheduled for execution or marked as done.</warning>', [$identifier]);
+            } else {
+                $output->outputLine('<em>Successfully executed upgrade wizard "%s".</em>', [$identifier]);
+                if (!empty($messages = array_filter($result->getMessages()))) {
+                    $output->outputLine('<info>Messages:</info>');
+                    foreach ($messages as $message) {
+                        $output->outputLine(html_entity_decode(strip_tags($message)));
+                    }
+                }
+                if (!empty($queries = array_filter($result->getSqlQueries()))) {
+                    $output->outputLine('<info>SQL Queries executed:</info>');
+                    foreach ($queries as $query) {
+                        $output->outputLine(html_entity_decode(($query)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -146,13 +146,13 @@ class CommandDispatcher
                 $dashedName = preg_replace('/([A-Z][a-z0-9]+)/', '$1-', $dashedName);
                 $dashedName = '--' . strtolower(substr($dashedName, 0, -1));
             }
-            $processBuilder->add($dashedName);
             if ($argumentValue !== null) {
                 if ($argumentValue === false) {
                     // Convert boolean false to 'false' instead of empty string to correctly pass the value to the sub command
+                    $processBuilder->add($dashedName);
                     $processBuilder->add('false');
                 } else {
-                    $processBuilder->add($argumentValue);
+                    $processBuilder->add($dashedName . '=' . $argumentValue);
                 }
             }
         }

--- a/Classes/Mvc/Cli/FailedSubProcessCommandException.php
+++ b/Classes/Mvc/Cli/FailedSubProcessCommandException.php
@@ -58,13 +58,13 @@ class FailedSubProcessCommandException extends \Exception
         if (empty($outputMessage . $errorMessage)) {
             $errorMessage = sprintf(
                 "Executing \"%s\" failed (exit code: \"%d\") with no message\n",
-                $command,
+                $commandLine,
                 $exitCode
             );
         } else {
             $errorMessage = sprintf(
                 "Executing \"%s\" failed (exit code: \"%d\") with message:\n\n\"%s\"\n\nand error:\n\n\"%s\"\n",
-                $command,
+                $commandLine,
                 $exitCode,
                 $outputMessage,
                 $errorMessage

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -12,6 +12,7 @@ return [
         \Helhum\Typo3Console\Command\ConfigurationCommandController::class,
         \Helhum\Typo3Console\Command\FrontendCommandController::class,
         \Helhum\Typo3Console\Command\ExtensionCommandController::class,
+        \Helhum\Typo3Console\Command\UpgradeCommandController::class,
     ],
     'runLevels' => [
         'typo3_console:install:databasedata' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
@@ -22,6 +23,8 @@ return [
         'typo3_console:configuration:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        'typo3_console:upgrade:subprocess' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
+        'typo3_console:upgrade:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
     ],
     'bootingSteps' => [
         'typo3_console:install:databasedata' => ['helhum.typo3console:database'],

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -16,7 +16,7 @@ Command Reference
   in the binary directory specified in the root composer.json (by default ``vendor/bin``)
 
 
-The following reference was automatically generated from code on 2017-04-06 15:25:57
+The following reference was automatically generated from code on 2017-04-17 13:03:22
 
 
 .. _`Command Reference: typo3_console`:
@@ -894,6 +894,81 @@ Options
   Uid of the task that should be executed (instead of all scheduled tasks)
 ``--force``
   The execution can be forced with this flag. The task will then be executed even if it is not scheduled for execution yet. Only works, when a task is specified.
+
+
+
+
+
+.. _`Command Reference: typo3_console upgrade:list`:
+
+``upgrade:list``
+****************
+
+**List upgrade wizards**
+
+
+
+
+
+Options
+^^^^^^^
+
+``--verbose``
+  If set, a more verbose description for each wizard is shown, if not set only the title is shown
+``--all``
+  If set, all wizards will be listed, even the once marked as ready or done
+
+
+
+
+
+.. _`Command Reference: typo3_console upgrade:run`:
+
+``upgrade:run``
+***************
+
+**Execute all upgrade wizards that are scheduled for execution**
+
+
+
+
+
+Options
+^^^^^^^
+
+``--arguments``
+  Arguments for the wizard prefixed with the identifier, e.g. ``compatibility7Extension[install]=0``; multiple arguments separated with comma
+``--verbose``
+  If set, output of the wizards will be shown, including all SQL Queries that were executed
+
+
+
+
+
+.. _`Command Reference: typo3_console upgrade:wizard`:
+
+``upgrade:wizard``
+******************
+
+**Execute a single upgrade wizard**
+
+
+
+Arguments
+^^^^^^^^^
+
+``--identifier``
+  Identifier of the wizard that should be executed
+
+
+
+Options
+^^^^^^^
+
+``--arguments``
+  Arguments for the wizard prefixed with the identifier, e.g. ``compatibility7Extension[install]=0``
+``--force``
+  Force execution, even if the wizard has been marked as done
 
 
 

--- a/Tests/Unit/Install/Upgrade/Fixture/DummyUpgradeWizard.php
+++ b/Tests/Unit/Install/Upgrade/Fixture/DummyUpgradeWizard.php
@@ -1,0 +1,34 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+class DummyUpgradeWizard extends AbstractUpdate
+{
+    public function checkForUpdate(&$description)
+    {
+        // Dummy
+    }
+
+    public function performUpdate(array &$dbQueries, &$customMessage)
+    {
+        // Dummy
+    }
+
+    public function markWizardAsDone($confValue = 1)
+    {
+        parent::markWizardAsDone($confValue);
+    }
+}

--- a/Tests/Unit/Install/Upgrade/UpgradeWizardExecutorTest.php
+++ b/Tests/Unit/Install/Upgrade/UpgradeWizardExecutorTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardExecutor;
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardFactory;
+use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\DummyUpgradeWizard;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+
+class UpgradeWizardExecutorTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function wizardIsNotCalledWhenDone()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(false);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test');
+        $this->assertFalse($result->hasPerformed());
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsCalledWhenNotDone()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(true);
+        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(true);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test');
+        $this->assertTrue($result->hasPerformed());
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsCalledWhenNotDoneButCanStillNotPerform()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(true);
+        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(false);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test');
+        $this->assertFalse($result->hasPerformed());
+    }
+
+    /**
+     * @test
+     */
+    public function wizardIsDoneButCalledWhenForced()
+    {
+        $factoryProphecy = $this->prophesize(UpgradeWizardFactory::class);
+        $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
+        $upgradeWizardProphecy->shouldRenderWizard()->willReturn(false);
+        $upgradeWizardProphecy->markWizardAsDone(0)->shouldBeCalled();
+        $upgradeWizardProphecy->performUpdate($queries = [], $message = '')->willReturn(true);
+
+        $factoryProphecy->create('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+
+        $subject = new UpgradeWizardExecutor($factoryProphecy->reveal());
+        $result = $subject->executeWizard('Foo\\Test', [], true);
+        $this->assertFalse($result->hasPerformed());
+    }
+}

--- a/Tests/Unit/Install/Upgrade/UpgradeWizardFactoryTest.php
+++ b/Tests/Unit/Install/Upgrade/UpgradeWizardFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Install\Upgrade;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Install\Upgrade\UpgradeWizardFactory;
+use Helhum\Typo3Console\Tests\Unit\Install\Upgrade\Fixture\DummyUpgradeWizard;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+class UpgradeWizardFactoryTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function createsWizardFromRegistry()
+    {
+        $registryFixture = [
+            'id' => 'Foo\\Test',
+        ];
+
+        $objectManagerProphecy = $this->prophesize(ObjectManager::class);
+        $upgradeWizardProphecy = $this->prophesize(AbstractUpdate::class);
+
+        $objectManagerProphecy->get('Foo\\Test')->willReturn($upgradeWizardProphecy->reveal());
+        $upgradeWizardProphecy->setIdentifier('id');
+
+        $subject = new UpgradeWizardFactory($objectManagerProphecy->reveal(), $registryFixture);
+        $this->assertSame($upgradeWizardProphecy->reveal(), $subject->create('id'));
+    }
+
+    /**
+     * @test
+     */
+    public function createsWizardWithClassName()
+    {
+        $registryFixture = [];
+
+        $objectManagerProphecy = $this->prophesize(ObjectManager::class);
+        $upgradeWizardProphecy = $this->prophesize(DummyUpgradeWizard::class);
+
+        $objectManagerProphecy->get(DummyUpgradeWizard::class)->willReturn($upgradeWizardProphecy->reveal());
+        $upgradeWizardProphecy->setIdentifier(DummyUpgradeWizard::class);
+
+        $subject = new UpgradeWizardFactory($objectManagerProphecy->reveal(), $registryFixture);
+        $this->assertSame($upgradeWizardProphecy->reveal(), $subject->create(DummyUpgradeWizard::class));
+    }
+
+    /**
+     * @test
+     */
+    public function createsCoreWizardFromRegistry()
+    {
+        $registryFixture = [
+            'TYPO3\\CMS\\Install\\Updates\\FooUpgrade' => 'TYPO3\\CMS\\Install\\Updates\\FooUpgrade',
+        ];
+
+        $objectManagerProphecy = $this->prophesize(ObjectManager::class);
+        $upgradeWizardProphecy = $this->prophesize(AbstractUpdate::class);
+
+        $objectManagerProphecy->get('TYPO3\\CMS\\Install\\Updates\\FooUpgrade')->willReturn($upgradeWizardProphecy->reveal());
+        $upgradeWizardProphecy->setIdentifier('TYPO3\\CMS\\Install\\Updates\\FooUpgrade');
+
+        $subject = new UpgradeWizardFactory($objectManagerProphecy->reveal(), $registryFixture);
+        $this->assertSame($upgradeWizardProphecy->reveal(), $subject->create('FooUpgrade'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionCode 1491914890
+     * @test
+     */
+    public function throwsExceptionForInvalidIdentifier()
+    {
+        $registryFixture = [
+            'TYPO3\\CMS\\Install\\Updates\\FooUpgrade' => 'TYPO3\\CMS\\Install\\Updates\\FooUpgrade',
+        ];
+        $objectManagerProphecy = $this->prophesize(ObjectManager::class);
+
+        $subject = new UpgradeWizardFactory($objectManagerProphecy->reveal(), $registryFixture);
+        $subject->create('foo');
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,7 @@ test_script:
   - .Build\bin\phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/
   - SET TYPO3_PATH_ROOT=c:\t3c\.Build\Web
   - echo %TYPO3_PATH_ROOT%
+  - DIR %TYPO3_PATH_ROOT%
   - echo %TYPO3_CONSOLE_DEBUG%
   - php Scripts/typo3cms
   - php Scripts/typo3cms install:setup --non-interactive --database-user-name="root" --database-user-password="Password12!" --database-host-name="localhost" --database-port="3306" --database-name="appveyor_test" --admin-user-name="admin" --admin-password="password" --site-name="Appveyor Install" --site-setup-type="createsite"


### PR DESCRIPTION
Add new upgrade:* commands to list necessary upgrade steps,
run through all the steps, or execute single steps out of the list.

To achieve this, a bunch of classes are added with a clean,
stable and straightforward API.

The commands handle the upgrade steps, but (of course)
do NOT perform the code update itself. This still needs
to be done manually (e.g. via Composer) beforehand.

So basically these commands are a replacement for the (manual)
click-through in the TYPO3 Install Tool AFTER code update.