### PR TITLE
[BUGFIX] Fix Composer commandline for extension dummy

### DIFF
--- a/Classes/Composer/InstallerScript/InstallDummyExtension.php
+++ b/Classes/Composer/InstallerScript/InstallDummyExtension.php
@@ -56,7 +56,7 @@ class InstallDummyExtension implements InstallerScriptInterface
             $io->writeError('<warning>Installation of TYPO3 extension has been deprecated</warning>');
             $io->writeError('<warning>To get rid of this message, set "install-extension-dummy" option to false</warning>');
             $io->writeError('<warning>Use the following command to set this option:</warning>');
-            $io->writeError('<warning>composer config extra.helhum/typo3-console.install-extension-dummy false</warning>');
+            $io->writeError('<warning>composer config extra.helhum/typo3-console.install-extension-dummy 0</warning>');
 
             $extResourcesDir = __DIR__ . '/../../../Resources/Private/ExtensionArtifacts';
             $resources = [


### PR DESCRIPTION
Composer does not cast the string "false" to actual false
in the extra section. Therefore we must use a "0" here
to make the composer config command write a config
that actually works.