### PR TITLE
[BUGFIX] Check for correct entry script

### DIFF
--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -45,7 +45,12 @@ call_user_func(function () {
     }
 
     define('PATH_site', \TYPO3\CMS\Core\Utility\GeneralUtility::fixWindowsFilePath(getenv('TYPO3_PATH_ROOT')) . '/');
-    define('PATH_thisScript', PATH_site . 'typo3/cli_dispatch.phpsh');
+    if (file_exists(PATH_site . 'typo3/sysext/core/bin/typo3')) {
+        define('PATH_thisScript', PATH_site . 'typo3/sysext/core/bin/typo3');
+    } else {
+        // @deprecated will be removed once 7.6 support is removed
+        define('PATH_thisScript', PATH_site . 'typo3/cli_dispatch.phpsh');
+    }
 
     $log('PATH_site: ' . PATH_site, true);
     $log('PATH_thisScript: ' . PATH_thisScript, true);


### PR DESCRIPTION
In TYPO3 master cli_dispatch.phpsh has been removed.
Check for the new script and use this as entry script