### PR TITLE
[BUGFIX] Make empty argument values work again

### DIFF
--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -146,13 +146,20 @@ class CommandDispatcher
                 $dashedName = preg_replace('/([A-Z][a-z0-9]+)/', '$1-', $dashedName);
                 $dashedName = '--' . strtolower(substr($dashedName, 0, -1));
             }
-            if ($argumentValue !== null) {
-                if ($argumentValue === false) {
-                    // Convert boolean false to 'false' instead of empty string to correctly pass the value to the sub command
-                    $processBuilder->add($dashedName);
-                    $processBuilder->add('false');
-                } else {
-                    $processBuilder->add($dashedName . '=' . $argumentValue);
+            if (strpos($argumentValue, '=') !== false) {
+                // Big WTF in argument parsing here
+                // If the value contains a = we need to separate the name and value with a = ourselves
+                // to get the parser to correctly read our value
+                $processBuilder->add($dashedName . '=' . $argumentValue);
+            } else {
+                $processBuilder->add($dashedName);
+                if ($argumentValue !== null) {
+                    if ($argumentValue === false) {
+                        // Convert boolean false to 'false' instead of empty string to correctly pass the value to the sub command
+                        $processBuilder->add('false');
+                    } else {
+                        $processBuilder->add($argumentValue);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is a mitigation for #463

Use --arg=value syntax for values that contain a =
and --arg '' syntax for empty values, so that at least
sub processes work correctly

We cannot fix the toplevel entry point command though as this
needs a fix in TYPO3 (or correctly supplied syntax by the user)