### PR TITLE
[TASK] Move functional tests to PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,11 @@ notifications:
     - helmut@typo3.org
 
 before_install:
-  - export COMPOSER_ROOT_VERSION=4.5.3
+  - |
+    export COMPOSER_ROOT_VERSION=4.5.3
+    export CONSOLE_ROOT="$PWD"
+    export TYPO3_PATH_ROOT="$CONSOLE_ROOT/.Build/Web"
+    export PATH="$PATH:./Scripts"
   - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
   - wget https://raw.github.com/lehmannro/assert.sh/v1.1/assert.sh && source assert.sh -v -x && rm assert.sh
 
@@ -52,85 +56,19 @@ before_script:
       composer set-version $TRAVIS_TAG
       # If this fails, we forgot to update version numbers before tagging the release
       test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
+      typo3cms | grep $TRAVIS_TAG
     fi
   - composer extension-create-libs && ls -la Libraries/*.phar | grep -v ^-rwx
   - git clean -dffx
   - composer require typo3/cms="$TYPO3_VERSION"
-  - export TYPO3_PATH_ROOT="$PWD/.Build/Web"
-  - export PATH="$PATH:./Scripts"
 
 script:
   - >
-    echo;
-    echo "Running unit tests";
-    .Build/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/
-  - >
-    echo;
     echo "Running php lint";
-    find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
-
-  # Basic functional tests - all commands should exit with 0
+    find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;;
   - >
-    if [ -n "$TRAVIS_TAG" ]; then
-      typo3cms | grep $TRAVIS_TAG
-    fi
-  - assert_raises "typo3cms foo" 1
-  - typo3cms help && [ ! -f "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php" ]
-  - typo3cms install:setup --non-interactive --database-user-name="root" --database-host-name="localhost" --database-port="3306" --database-name="travis_test" --admin-user-name="admin" --admin-password="password" --site-name="Travis Install" --site-setup-type="createsite"
-  - echo 'select uid,title from pages limit 1' | typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home
-  - chmod ugo-w $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php && typo3cms extension:setupactive && chmod ug+w $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php
-  - typo3cms help
-  - typo3cms help:autocomplete
-  - typo3cms help:autocomplete bash
-  - typo3cms help:autocomplete zsh
-  - typo3cms backend:lock
-  - typo3cms backend:lock
-  - typo3cms backend:unlock
-  - typo3cms backend:unlock
-  - typo3cms backend:lockforeditors
-  - typo3cms backend:lockforeditors
-  - typo3cms backend:unlockforeditors
-  - typo3cms backend:unlockforeditors
-  - typo3cms cache:flush
-  - typo3cms cache:flushgroups pages
-  - typo3cms cache:flushtags foo
-  - typo3cms cache:flushtags foo pages
-  - typo3cms cache:listgroups
-  - typo3cms cleanup:updatereferenceindex
-  - typo3cms database:updateschema "*" --verbose --dry-run
-  - typo3cms database:updateschema --verbose
-  - typo3cms database:updateschema "*" --verbose
-  - typo3cms database:export > travis_test.sql
-  - test $(typo3cms database:export --exclude-tables sys_log | grep "CREATE TABLE" | grep -c sys_log) -eq 0
-  - echo "SELECT username from be_users where admin=1;" | typo3cms database:import
-  - echo "DROP DATABASE travis_test;" | typo3cms database:import
-  - echo "CREATE DATABASE travis_test;" | mysql -uroot && cat travis_test.sql | typo3cms database:import
-  - typo3cms database:updateschema "*" --verbose
-  - typo3cms frontend:request / > /dev/null
-  - typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null
-  - typo3cms configuration:show BE/installToolPassword
-  - typo3cms configuration:showLocal BE/installToolPassword
-  - typo3cms configuration:showActive BE/installToolPassword
-  - typo3cms configuration:set BE/installToolPassword foobar && grep installToolPassword $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php | grep foobar
-  - typo3cms configuration:remove BE/installToolPassword --force && grep -qv installToolPassword $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php
-  - typo3cms configuration:set BE/installToolPassword blablupp && grep installToolPassword $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php | grep blablupp
-  - typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php
-  - typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php | grep baz
-  - rm -f $TYPO3_PATH_ROOT/typo3conf/PackageStates.php && typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php" ]
-  - rm -f $TYPO3_PATH_ROOT/typo3conf/PackageStates.php && TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES=yes TYPO3_CONSOLE_TEST_SETUP=yes TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS=yes composer dump-autoload -vv 2>&1 | grep 'generated PackageStates.php' && [ -f "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php" ]
-  - grep sys_note "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php"
-  - rm $TYPO3_PATH_ROOT/typo3temp/index.html && typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_ROOT/typo3temp/index.html" ]
-  - typo3cms extension:list
-  - typo3cms extension:list --raw | grep extbase
-  - typo3cms extension:list --active --raw | grep extbase
-  - typo3cms extension:list --inactive --raw | tr '\n' ' ' | grep -v extbase
-  - cp -r Tests/Functional/Fixtures/ext_test .Build/Web/typo3conf/ext/
-  - typo3cms extension:activate ext_test && typo3cms cache:flush && typo3cms database:updateschema | grep 'No schema updates were performed'
-  - typo3cms extension:activate core && typo3cms database:updateschema | grep 'No schema updates were performed'
-  - typo3cms extension:setup core && typo3cms database:updateschema | grep 'No schema updates were performed'
-  - typo3cms extension:setupactive && typo3cms database:updateschema | grep 'No schema updates were performed'
-  - if typo3cms extension:list --raw | grep dbal; then typo3cms extension:activate adodb,dbal && typo3cms database:updateschema | grep 'No schema updates were performed'; fi
-  - typo3cms extension:removeinactive --force | grep 'The following directories have been removed'
+    echo "Running unit and functional tests…";
+    .Build/bin/phpunit;
 
 after_script:
   - >

--- a/Classes/Command/BackendCommandController.php
+++ b/Classes/Command/BackendCommandController.php
@@ -31,13 +31,13 @@ class BackendCommandController extends CommandController
     public function lockCommand($redirectUrl = null)
     {
         if (@is_file(PATH_typo3conf . 'LOCK_BACKEND')) {
-            $this->outputLine('<warning>Backend is already locked!</warning>');
-            $this->sendAndExit(0);
+            $this->outputLine('<warning>Backend is already locked.</warning>');
+            $this->quit(0);
         }
         \TYPO3\CMS\Core\Utility\GeneralUtility::writeFile(PATH_typo3conf . 'LOCK_BACKEND', (string)$redirectUrl);
         if (!@is_file(PATH_typo3conf . 'LOCK_BACKEND')) {
-            $this->outputLine('<error>Could not create lock file \'typo3conf/LOCK_BACKEND\'!</error>');
-            $this->sendAndExit(2);
+            $this->outputLine('<error>Could not create lock file \'typo3conf/LOCK_BACKEND\'.</error>');
+            $this->quit(2);
         } else {
             $this->outputLine('<info>Backend has been locked. Access is denied for every user until it is unlocked again.</info>');
             if ($redirectUrl !== null) {
@@ -55,13 +55,13 @@ class BackendCommandController extends CommandController
     public function unlockCommand()
     {
         if (!@is_file(PATH_typo3conf . 'LOCK_BACKEND')) {
-            $this->outputLine('<warning>Backend is already unlocked!</warning>');
-            $this->sendAndExit(0);
+            $this->outputLine('<warning>Backend is already unlocked.</warning>');
+            $this->quit(0);
         }
         unlink(PATH_typo3conf . 'LOCK_BACKEND');
         if (@is_file(PATH_typo3conf . 'LOCK_BACKEND')) {
-            $this->outputLine('<error>Could not remove lock file \'typo3conf/LOCK_BACKEND\'!</error>');
-            $this->sendAndExit(2);
+            $this->outputLine('<error>Could not remove lock file \'typo3conf/LOCK_BACKEND\'.</error>');
+            $this->quit(2);
         } else {
             $this->outputLine('<info>Backend lock is removed. User can now access the backend again.</info>');
         }
@@ -90,10 +90,9 @@ class BackendCommandController extends CommandController
         $lockedForEditors = $this->configurationService->getLocal('BE/adminOnly') !== self::LOCK_TYPE_UNLOCKED;
         if (!$lockedForEditors) {
             $this->configurationService->setLocal('BE/adminOnly', self::LOCK_TYPE_ADMIN);
-            $this->outputLine('<info>Locked backend for editor access!</info>');
+            $this->outputLine('<info>Locked backend for editor access.</info>');
         } else {
             $this->outputLine('<warning>The backend was already locked for editors, hence nothing was done.</warning>');
-            $this->sendAndExit(0);
         }
     }
 
@@ -110,10 +109,9 @@ class BackendCommandController extends CommandController
         $lockedForEditors = $this->configurationService->getLocal('BE/adminOnly') !== self::LOCK_TYPE_UNLOCKED;
         if ($lockedForEditors) {
             $this->configurationService->setLocal('BE/adminOnly', self::LOCK_TYPE_UNLOCKED);
-            $this->outputLine('<info>Unlocked backend for editors!</info>');
+            $this->outputLine('<info>Unlocked backend for editors.</info>');
         } else {
-            $this->outputLine('<warning>The backend was not locked for editors, hence nothing was done.</warning>');
-            $this->sendAndExit(0);
+            $this->outputLine('<warning>The backend was not locked for editors.</warning>');
         }
     }
 
@@ -124,7 +122,7 @@ class BackendCommandController extends CommandController
     {
         if (!$this->configurationService->localIsActive('BE/adminOnly')) {
             $this->outputLine('<error>The configuration value BE/adminOnly is not modifiable. Is it forced to a value in Additional Configuration?</error>');
-            $this->sendAndExit(2);
+            $this->quit(2);
         }
     }
 }

--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -91,7 +91,7 @@ class CacheCommandController extends CommandController
     {
         try {
             $this->cacheService->flushGroups($groups);
-            $this->outputLine('Flushed all caches for group(s): "' . implode('","', $groups) . '"');
+            $this->outputLine('Flushed all caches for group(s): "' . implode('","', $groups) . '".');
         } catch (NoSuchCacheGroupException $e) {
             $this->outputLine($e->getMessage());
             $this->sendAndExit(1);
@@ -113,9 +113,9 @@ class CacheCommandController extends CommandController
         try {
             $this->cacheService->flushByTagsAndGroups($tags, $groups);
             if ($groups === null) {
-                $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '"');
+                $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '".');
             } else {
-                $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '" in groups: "' . implode('","', $groups) . '"');
+                $this->outputLine('Flushed caches by tags "' . implode('","', $tags) . '" in groups: "' . implode('","', $groups) . '".');
             }
         } catch (NoSuchCacheGroupException $e) {
             $this->outputLine($e->getMessage());

--- a/Classes/Command/ExtensionCommandController.php
+++ b/Classes/Command/ExtensionCommandController.php
@@ -298,7 +298,7 @@ class ExtensionCommandController extends CommandController
         } else {
             $this->output->outputTable(
                 $extensionInformation,
-                ['Package key', 'Version', 'Description']
+                ['Extension key', 'Version', 'Description']
             );
         }
     }

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -118,6 +118,7 @@ class CliSetupRequestHandler
         }
         // The TYPO3 installation process does not take care of setting up all extensions properly,
         // so we do it manually here
+        $this->commandDispatcher->executeCommand('install:generatepackagestates', ['--activate-default' => true]);
         $this->commandDispatcher->executeCommand('extension:setupactive');
     }
 

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -170,7 +170,7 @@ class CacheService implements SingletonInterface
         $sanitizedGroups = array_intersect($groups, $validGroups);
         if (count($sanitizedGroups) !== count($groups)) {
             $invalidGroups = array_diff($groups, $sanitizedGroups);
-            throw new NoSuchCacheGroupException('Invalid cache groups "' . implode(', ', $invalidGroups) . '"', 1399630162);
+            throw new NoSuchCacheGroupException('Invalid cache groups "' . implode(', ', $invalidGroups) . '".', 1399630162);
         }
     }
 

--- a/Tests/Functional/Command/AbstractCommandTest.php
+++ b/Tests/Functional/Command/AbstractCommandTest.php
@@ -1,0 +1,166 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\ProcessBuilder;
+
+abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CommandDispatcher
+     */
+    protected $commandDispatcher;
+
+    protected function setUp()
+    {
+        if (!file_exists(getenv('TYPO3_PATH_ROOT') . '/index.php')
+            && strpos(getenv('TYPO3_PATH_ROOT'), '.Build/Web') === false
+        ) {
+            throw new \RuntimeException('TYPO3_PATH_ROOT is not properly set!', 1493574402);
+        }
+        $this->commandDispatcher = CommandDispatcher::createFromTestRun();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDatabaseConnectionSettings()
+    {
+        return [
+            'dbUser' => getenv('TYPO3_INSTALL_DB_USER') ?: 'root',
+            'dbPassword' => getenv('TYPO3_INSTALL_DB_PASSWORD') ?: '',
+            'dbName' => getenv('TYPO3_INSTALL_DB_DBNAME') ?: 'travis_console_test',
+        ];
+    }
+
+    /**
+     * @param string $sql
+     * @param bool $useDatabase
+     * @return string
+     */
+    protected function executeMysqlQuery($sql, $useDatabase = true)
+    {
+        $settings = $this->getDatabaseConnectionSettings();
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setPrefix('mysql');
+        $processBuilder->add('--skip-column-names');
+        $processBuilder->add('-u');
+        $processBuilder->add($settings['dbUser']);
+        $processBuilder->add('--password=' . $settings['dbPassword']);
+        if ($useDatabase) {
+            $processBuilder->add($settings['dbName']);
+        }
+        $processBuilder->setInput($sql);
+
+        $mysqlProcess = $processBuilder->getProcess();
+        $mysqlProcess->run();
+        if (!$mysqlProcess->isSuccessful()) {
+            throw new \RuntimeException(sprintf('Executing query "%s" failed', $sql), 1493634196);
+        }
+        return $mysqlProcess->getOutput();
+    }
+
+    protected function backupDatabase()
+    {
+        $settings = $this->getDatabaseConnectionSettings();
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setPrefix('mysqldump');
+        $processBuilder->add('-u');
+        $processBuilder->add($settings['dbUser']);
+        $processBuilder->add('--password=' . $settings['dbPassword']);
+        $processBuilder->add($settings['dbName']);
+
+        $mysqlProcess = $processBuilder->getProcess();
+        $mysqlProcess->run();
+        if (!$mysqlProcess->isSuccessful()) {
+            throw new \RuntimeException('Backing up database failed', 1493634217);
+        }
+        file_put_contents(getenv('TYPO3_PATH_ROOT') . '/typo3temp/' . $settings['dbName'] . '.sql', $mysqlProcess->getOutput());
+    }
+
+    protected function restoreDatabase()
+    {
+        $settings = $this->getDatabaseConnectionSettings();
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setPrefix('mysql');
+        $processBuilder->add('-u');
+        $processBuilder->add($settings['dbUser']);
+        $processBuilder->add('--password=' . $settings['dbPassword']);
+        $processBuilder->add($settings['dbName']);
+        $processBuilder->setInput(file_get_contents(getenv('TYPO3_PATH_ROOT') . '/typo3temp/' . $settings['dbName'] . '.sql'));
+
+        $mysqlProcess = $processBuilder->getProcess();
+        $mysqlProcess->run();
+        if (!$mysqlProcess->isSuccessful()) {
+            throw new \RuntimeException('Restoring database failed', 1493634218);
+        }
+        unlink(getenv('TYPO3_PATH_ROOT') . '/typo3temp/' . $settings['dbName'] . '.sql');
+    }
+
+    /**
+     * @param string $extensionKey
+     */
+    protected function installFixtureExtensionCode($extensionKey)
+    {
+        $sourcePath = dirname(__DIR__) . '/Fixtures/' . $extensionKey;
+        $targetPath = getenv('TYPO3_PATH_ROOT') . '/typo3conf/ext/' . $extensionKey;
+        $this->copyDirectory($sourcePath, $targetPath);
+    }
+
+    /**
+     * @param string $sourcePath
+     * @param string $targetPath
+     */
+    protected function copyDirectory($sourcePath, $targetPath)
+    {
+        $fileSystem = new Filesystem();
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($sourcePath, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            $target = $targetPath . '/' . $iterator->getSubPathName();
+            if ($item->isDir()) {
+                $fileSystem->mkdir($target);
+            } else {
+                $fileSystem->copy($item->getPathname(), $target);
+            }
+        }
+    }
+
+    /**
+     * @param string $extensionKey
+     */
+    protected function removeFixtureExtensionCode($extensionKey)
+    {
+        $this->removeDirectory(getenv('TYPO3_PATH_ROOT') . '/typo3conf/ext/' . $extensionKey);
+    }
+
+    /**
+     * @param string $targetPath
+     */
+    protected function removeDirectory($targetPath)
+    {
+        $fileSystem = new Filesystem();
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($targetPath, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+        $fileSystem->remove($iterator);
+        $fileSystem->remove($targetPath);
+    }
+}

--- a/Tests/Functional/Command/BackendCommandControllerTest.php
+++ b/Tests/Functional/Command/BackendCommandControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class BackendCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function backendCanBeLockedAndUnlocked()
+    {
+        $output = $this->commandDispatcher->executeCommand('backend:lock');
+        $this->assertContains('Backend has been locked', $output);
+        $output = $this->commandDispatcher->executeCommand('backend:lock');
+        $this->assertContains('Backend is already locked', $output);
+        $output = $this->commandDispatcher->executeCommand('backend:unlock');
+        $this->assertContains('Backend lock is removed', $output);
+        $output = $this->commandDispatcher->executeCommand('backend:unlock');
+        $this->assertContains('Backend is already unlocked', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function backendCanBeLockedAndUnlockedForEditors()
+    {
+        $output = $this->commandDispatcher->executeCommand('backend:lockforeditors');
+        $this->assertContains('Locked backend for editor access', $output);
+        $output = $this->commandDispatcher->executeCommand('backend:lockforeditors');
+        $this->assertContains('The backend was already locked for editors', $output);
+        $output = $this->commandDispatcher->executeCommand('backend:unlockforeditors');
+        $this->assertContains('Unlocked backend for editors', $output);
+        $output = $this->commandDispatcher->executeCommand('backend:unlockforeditors');
+        $this->assertContains('The backend was not locked for editors', $output);
+    }
+}

--- a/Tests/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Functional/Command/CacheCommandControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+
+class CacheCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function cacheCanBeFlushedFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flush');
+        $this->assertSame('Flushed all caches.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function cacheCanBeForceFlushedFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flush', ['--force' => true]);
+        $this->assertSame('Force flushed all caches.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function cacheGroupsCanBeFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flushgroups', ['--groups' => 'pages']);
+        $this->assertSame('Flushed all caches for group(s): "pages".', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function invalidGroupsMakesCommandFail()
+    {
+        try {
+            $this->commandDispatcher->executeCommand('cache:flushgroups', ['--groups' => 'foo']);
+        } catch (FailedSubProcessCommandException $e) {
+            $this->assertSame(1, $e->getExitCode());
+            $this->assertContains('Invalid cache groups "foo".', $e->getErrorMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function cacheGroupsCanBeListed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:listgroups');
+        $this->assertContains('The following cache groups are registered: ', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function cacheTagsCanBeFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flushtags', ['--tags' => 'foo']);
+        $this->assertSame('Flushed caches by tags "foo".', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function cacheTagsAndGroupsCanBeFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flushtags', ['--tags' => 'foo', '--groups' => 'pages']);
+        $this->assertSame('Flushed caches by tags "foo" in groups: "pages".', $output);
+    }
+}

--- a/Tests/Functional/Command/CleanupCommandControllerTest.php
+++ b/Tests/Functional/Command/CleanupCommandControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class CleanupCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function referenceIndexIsUpdated()
+    {
+        $output = $this->commandDispatcher->executeCommand('cleanup:updatereferenceindex');
+        $this->assertContains('Updating reference index', $output);
+    }
+}

--- a/Tests/Functional/Command/ConfigurationCommandControllerTest.php
+++ b/Tests/Functional/Command/ConfigurationCommandControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class ConfigurationCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function configurationCanBeShown()
+    {
+        $output = $this->commandDispatcher->executeCommand('configuration:show', ['--path' => 'BE/installToolPassword']);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertContains($config['BE']['installToolPassword'], $output);
+    }
+
+    /**
+     * @test
+     */
+    public function localConfigurationCanBeShown()
+    {
+        $output = $this->commandDispatcher->executeCommand('configuration:showlocal', ['--path' => 'BE/installToolPassword']);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertContains($config['BE']['installToolPassword'], $output);
+    }
+
+    /**
+     * @test
+     */
+    public function activeConfigurationCanBeShown()
+    {
+        $output = $this->commandDispatcher->executeCommand('configuration:showactive', ['--path' => 'BE/installToolPassword']);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertContains($config['BE']['installToolPassword'], $output);
+    }
+
+    /**
+     * @test
+     */
+    public function configurationCanBeSet()
+    {
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $oldPassword = $config['BE']['installToolPassword'];
+        $this->commandDispatcher->executeCommand('configuration:set', ['--path' => 'BE/installToolPassword', '--value' => 'foobar']);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertSame('foobar', $config['BE']['installToolPassword']);
+        $this->commandDispatcher->executeCommand('configuration:set', ['--path' => 'BE/installToolPassword', '--value' => $oldPassword]);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertSame($oldPassword, $config['BE']['installToolPassword']);
+    }
+
+    /**
+     * @test
+     */
+    public function configurationCanBeRemovedAndSetAgainWithoutKeyPresent()
+    {
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $oldPassword = $config['BE']['installToolPassword'];
+        $this->commandDispatcher->executeCommand('configuration:remove', ['--path' => 'BE/installToolPassword', '--force' => true]);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertArrayNotHasKey('installToolPassword', $config['BE']);
+        $this->commandDispatcher->executeCommand('configuration:set', ['--path' => 'BE/installToolPassword', '--value' => $oldPassword]);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertSame($oldPassword, $config['BE']['installToolPassword']);
+    }
+
+    /**
+     * @test
+     */
+    public function numericalIndexedArraysCanBeSet()
+    {
+        $this->commandDispatcher->executeCommand('configuration:set', ['--path' => 'EXTCONF/lang/availableLanguages/0', '--value' => 'fr_FR']);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertSame('fr_FR', $config['EXTCONF']['lang']['availableLanguages'][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function associativeArraysCanBeSet()
+    {
+        $this->commandDispatcher->executeCommand('configuration:set', ['--path' => 'EXTCONF/foo/bar', '--value' => 'baz']);
+        $config = require getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php';
+        $this->assertSame('baz', $config['EXTCONF']['foo']['bar']);
+    }
+}

--- a/Tests/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Functional/Command/DatabaseCommandControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class DatabaseCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function safeUpdatesCanBePerformedWithNoFurtherArguments()
+    {
+        $output = $this->commandDispatcher->executeCommand('database:updateschema');
+        $this->assertContains('No schema updates were performed for update types:', $output);
+        $this->assertContains('"field.add", "field.change", "table.add", "table.change"', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function allUpdatesCanBePerformedWhenSpecified()
+    {
+        $output = $this->commandDispatcher->executeCommand('database:updateschema', ['--schema-update-types' => '*', '--verbose' => true]);
+        $this->assertContains('No schema updates were performed for update types:', $output);
+        $this->assertContains('"field.add", "field.change", "field.prefix", "field.drop", "table.add", "table.change", "table.prefix", "table.drop"', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function addingAndRemovingFieldsAndTablesIncludingVerbositySwitchWork()
+    {
+        $this->installFixtureExtensionCode('ext_test');
+        $this->commandDispatcher->executeCommand('install:generatepackagestates', ['--activate-default' => true]);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema', ['--schema-update-types' => '*', '--verbose' => true]);
+
+        $this->assertContains('The following database schema updates were performed:', $output);
+        $this->assertContains('Change fields', $output);
+        $this->assertContains('Add tables', $output);
+
+        $this->removeFixtureExtensionCode('ext_test');
+        $this->commandDispatcher->executeCommand('install:generatepackagestates', ['--activate-default' => true]);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema', ['--schema-update-types' => '*', '--verbose' => true]);
+
+        $this->assertContains('The following database schema updates were performed:', $output);
+        $this->assertContains('SQL Statements ', $output);
+        $this->assertContains('Change fields', $output);
+        $this->assertContains('Prefix tables', $output);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema', ['--schema-update-types' => '*']);
+
+        $this->assertContains('The following database schema updates were performed:', $output);
+        $this->assertNotContains('SQL Statements ', $output);
+        $this->assertContains('Drop tables', $output);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema', ['--schema-update-types' => '*', '--verbose' => true]);
+
+        $this->assertContains('No schema updates were performed for update types:', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function schemaUpdateCanBePerformedWithoutAnyTables()
+    {
+        $this->backupDatabase();
+        $this->executeMysqlQuery('DROP DATABASE ' . $this->getDatabaseConnectionSettings()['dbName'], false);
+        $this->executeMysqlQuery('CREATE DATABASE ' . $this->getDatabaseConnectionSettings()['dbName'], false);
+        $output = $this->commandDispatcher->executeCommand('database:updateschema', ['--schema-update-types' => '*']);
+        $this->assertContains('The following database schema updates were performed:', $output);
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function databaseCanBeExportedAndImported()
+    {
+        $this->backupDatabase();
+        $output = $this->commandDispatcher->executeCommand('database:export');
+        $this->executeMysqlQuery('DROP DATABASE ' . $this->getDatabaseConnectionSettings()['dbName'], false);
+        $this->executeMysqlQuery('CREATE DATABASE ' . $this->getDatabaseConnectionSettings()['dbName'], false);
+        $this->commandDispatcher->executeCommand('database:import', [], [], $output);
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function databaseExportCanExcludeTables()
+    {
+        $output = $this->commandDispatcher->executeCommand('database:export', ['--exclude-tables' => 'sys_log']);
+        $this->assertNotContains('CREATE TABLE `sys_log`', $output);
+    }
+}

--- a/Tests/Functional/Command/DocumentationCommandControllerTest.php
+++ b/Tests/Functional/Command/DocumentationCommandControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class DocumentationCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function schemaForFluidCanBeGenerated()
+    {
+        $output = $this->commandDispatcher->executeCommand('documentation:generatexsd', ['--php-namespace' => 'TYPO3\\CMS\\Fluid\\ViewHelpers']);
+        $this->assertContains('<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">', $output);
+    }
+}

--- a/Tests/Functional/Command/ExtensionCommandControllerTest.php
+++ b/Tests/Functional/Command/ExtensionCommandControllerTest.php
@@ -1,0 +1,185 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Symfony\Component\Filesystem\Filesystem;
+
+class ExtensionCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function extensionListShowsActiveAndInactiveExtensions()
+    {
+        $output = $this->commandDispatcher->executeCommand('extension:list');
+        $this->assertContains('Extension key', $output);
+        $this->assertContains('extbase', $output);
+        $this->assertContains('filemetadata', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function extensionListRawShowsActiveAndInactiveExtensionsButNoHeader()
+    {
+        $output = $this->commandDispatcher->executeCommand('extension:list', ['--raw' => true]);
+        $this->assertNotContains('Extension key', $output);
+        $this->assertContains('extbase', $output);
+        $this->assertContains('filemetadata', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function extensionListCanShowOnlyActiveExtensions()
+    {
+        $output = $this->commandDispatcher->executeCommand('extension:list', ['--active' => true, '--raw' => true]);
+        $this->assertContains('extbase', $output);
+        $this->assertNotContains('filemetadata', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function extensionListCanShowOnlyInActiveExtensions()
+    {
+        $output = $this->commandDispatcher->executeCommand('extension:list', ['--inactive' => true, '--raw' => true]);
+        $this->assertNotContains('extbase', $output);
+        $this->assertContains('filemetadata', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function extensionActivateCallsSchemaUpdate()
+    {
+        $this->backupDatabase();
+        $this->installFixtureExtensionCode('ext_test');
+
+        $output = $this->commandDispatcher->executeCommand('extension:activate', ['--extension-keys' => 'ext_test']);
+        $this->assertContains('Extension "ext_test" is now active.', $output);
+        $this->assertContains('Extension "ext_test" is now set up.', $output);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema');
+        $this->assertContains('No schema updates were performed for update types:', $output);
+
+        $output = $this->commandDispatcher->executeCommand('extension:deactivate', ['--extension-keys' => 'ext_test']);
+        $this->assertContains('Extension "ext_test" is now inactive.', $output);
+
+        $this->removeFixtureExtensionCode('ext_test');
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function extensionActivateOnAlreadyInstalledExtensionDoesNotDestroyCurrentSchema()
+    {
+        $this->backupDatabase();
+        $this->installFixtureExtensionCode('ext_test');
+
+        $output = $this->commandDispatcher->executeCommand('extension:activate', ['--extension-keys' => 'ext_test']);
+        $this->assertContains('Extension "ext_test" is now active.', $output);
+        $this->assertContains('Extension "ext_test" is now set up.', $output);
+
+        $output = $this->commandDispatcher->executeCommand('extension:activate', ['--extension-keys' => 'core']);
+        $this->assertNotContains('is now active.', $output);
+        $this->assertContains('Extension "core" is now set up.', $output);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema');
+        $this->assertContains('No schema updates were performed for update types:', $output);
+
+        $output = $this->commandDispatcher->executeCommand('extension:deactivate', ['--extension-keys' => 'ext_test']);
+        $this->assertContains('Extension "ext_test" is now inactive.', $output);
+
+        $this->removeFixtureExtensionCode('ext_test');
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function extensionSetupActivePerformsSchemaUpdate()
+    {
+        $this->backupDatabase();
+        $this->installFixtureExtensionCode('ext_test');
+        $this->commandDispatcher->executeCommand('install:generatepackagestates', ['--activate-default' => true]);
+
+        $output = $this->commandDispatcher->executeCommand('extension:setupactive');
+        $this->assertContains('ext_test', $output);
+        $this->assertContains('are now set up.', $output);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema');
+        $this->assertContains('No schema updates were performed for update types:', $output);
+
+        $output = $this->commandDispatcher->executeCommand('extension:deactivate', ['--extension-keys' => 'ext_test']);
+        $this->assertContains('Extension "ext_test" is now inactive.', $output);
+
+        $this->removeFixtureExtensionCode('ext_test');
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function extensionSetupDoesNotWriteLocalConfiguration()
+    {
+        $this->backupDatabase();
+        $filesystem = new Filesystem();
+        $filesystem->chmod(getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php', 0444);
+        $output = $this->commandDispatcher->executeCommand('extension:setupactive');
+        $this->assertContains('are now set up.', $output);
+
+        $filesystem->chmod(getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php', 0664);
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     * @deprecated can be removed once TYPO3 7.6 support is removed
+     */
+    public function dbalCacheTablesAreRespectedWhenDbalIsActive()
+    {
+        $output = $this->commandDispatcher->executeCommand('extension:list', ['--raw' => true]);
+        if (strpos($output, 'dbal') === false) {
+            // DBAL Extension is only available with TYPO3 versions 7.6.x
+            return;
+        }
+        $this->backupDatabase();
+
+        $output = $this->commandDispatcher->executeCommand('extension:activate', ['--extension-keys' => 'dbal,adodb']);
+        $this->assertContains('Extensions "dbal", "adodb" are now active.', $output);
+
+        $output = $this->commandDispatcher->executeCommand('database:updateschema');
+        $this->assertContains('No schema updates were performed for update types:', $output);
+
+        $output = $this->commandDispatcher->executeCommand('extension:deactivate', ['--extension-keys' => 'dbal,adodb']);
+        $this->assertContains('Extensions "dbal", "adodb" are now inactive.', $output);
+
+        $this->restoreDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function canRemoveInactiveExtensions()
+    {
+        $this->copyDirectory(getenv('TYPO3_PATH_ROOT') . '/typo3/sysext', getenv('TYPO3_PATH_ROOT') . '/typo3temp/sysext');
+
+        $output = $this->commandDispatcher->executeCommand('extension:removeinactive', ['--force' => true]);
+        $this->assertContains('filemetadata', $output);
+
+        $this->copyDirectory(getenv('TYPO3_PATH_ROOT') . '/typo3temp/sysext', getenv('TYPO3_PATH_ROOT') . '/typo3/sysext');
+    }
+}

--- a/Tests/Functional/Command/FrontendCommandControllerTest.php
+++ b/Tests/Functional/Command/FrontendCommandControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+class FrontendCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function homePageIsReturnedWhenRequested()
+    {
+        $output = $this->commandDispatcher->executeCommand('frontend:request', ['--request-url' => '/']);
+        $this->assertContains('Welcome to a default website made with', $output);
+    }
+}

--- a/Tests/Functional/Command/HelpCommandControllerTest.php
+++ b/Tests/Functional/Command/HelpCommandControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+
+class HelpCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function callingNotExistingCommandReturnsErrorCode()
+    {
+        try {
+            $this->commandDispatcher->executeCommand('foo');
+        } catch (FailedSubProcessCommandException $e) {
+            $this->assertSame(1, $e->getExitCode());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function helpShowsListOfAvailableCommands()
+    {
+        $output = $this->commandDispatcher->executeCommand('help');
+        $this->assertContains('Available commands', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function autoCompleteDefaultsToBash()
+    {
+        $output = $this->commandDispatcher->executeCommand('autocomplete');
+        $this->assertContains('#!/usr/bin/env bash', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function autoCompleteForBash()
+    {
+        $output = $this->commandDispatcher->executeCommand('autocomplete', ['shell' => 'bash']);
+        $this->assertContains('#!/usr/bin/env bash', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function autoCompleteForZsh()
+    {
+        $output = $this->commandDispatcher->executeCommand('autocomplete', ['shell' => 'zsh']);
+        $this->assertContains('#!/usr/bin/env zsh', $output);
+    }
+
+    /**
+     * @test
+     * @expectedException \Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException
+     */
+    public function wrongShellMakesAutoCompleteFail()
+    {
+        $this->commandDispatcher->executeCommand('autocomplete', ['shell' => 'wrong']);
+    }
+}

--- a/Tests/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Functional/Command/Install/InstallCommandControllerTest.php
@@ -1,0 +1,151 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Functional\Command\Install;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Tests\Functional\Command\AbstractCommandTest;
+use Symfony\Component\Process\ProcessBuilder;
+
+class InstallCommandControllerTest extends AbstractCommandTest
+{
+    /**
+     * @test
+     */
+    public function helpBeforeSetupDoesNotCreatePackageStatesFile()
+    {
+        @unlink(getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php');
+        $this->commandDispatcher->executeCommand('help');
+        $this->assertFalse(file_exists(getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php'));
+    }
+
+    /**
+     * @test
+     */
+    public function setupCommandWorksWithoutErrors()
+    {
+        $this->executeMysqlQuery('DROP DATABASE IF EXISTS ' . $this->getDatabaseConnectionSettings()['dbName'], false);
+        @unlink(getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php');
+        @unlink(getenv('TYPO3_PATH_ROOT') . '/typo3conf/LocalConfiguration.php');
+        $settings = $this->getDatabaseConnectionSettings();
+        $output = $this->commandDispatcher->executeCommand(
+            'install:setup',
+            [
+                '--non-interactive' => true,
+                '--database-user-name' => $settings['dbUser'],
+                '--database-user-password' => $settings['dbPassword'],
+                '--database-host-name' => 'localhost',
+                '--database-port' => '3306',
+                '--database-name' => $settings['dbName'],
+                '--admin-user-name' => 'admin',
+                '--admin-password' => 'password',
+                '--site-name' => 'Travis Install',
+                '--site-setup-type' => 'createsite',
+            ]
+        );
+        $this->assertContains('Successfully installed TYPO3 CMS!', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function siteSetupCreatedHomepage()
+    {
+        $queryResult = $this->executeMysqlQuery('SELECT uid,title FROM `pages` LIMIT 1;');
+        $this->assertSame('1Home', preg_replace('/\s+/', '', $queryResult));
+    }
+
+    /**
+     * @test
+     */
+    public function folderStructureIsCreated()
+    {
+        $indexFile = getenv('TYPO3_PATH_ROOT') . '/typo3temp/index.html';
+        @unlink($indexFile);
+        $this->commandDispatcher->executeCommand(
+            'install:fixfolderstructure'
+        );
+        $this->assertTrue(file_exists($indexFile));
+    }
+
+    /**
+     * @test
+     */
+    public function packageStatesFileIsCreatedWithoutDefaultPackages()
+    {
+        $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        @unlink($packageStatesFile);
+        $this->commandDispatcher->executeCommand(
+            'install:generatepackagestates'
+        );
+        $this->assertTrue(file_exists($packageStatesFile));
+        $packageConfig = require $packageStatesFile;
+        if ($packageConfig['version'] === 5) {
+            $this->assertArrayNotHasKey('reports', $packageConfig['packages']);
+        } else {
+            $this->assertSame('inactive', $packageConfig['packages']['reports']['state']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function packageStatesFileIsCreatedWithDefaultPackages()
+    {
+        $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        @unlink($packageStatesFile);
+        $this->commandDispatcher->executeCommand(
+            'install:generatepackagestates',
+            [
+                '--activate-default' => true,
+            ]
+        );
+        $this->assertTrue(file_exists($packageStatesFile));
+        $packageConfig = require $packageStatesFile;
+        if ($packageConfig['version'] === 5) {
+            $this->assertArrayHasKey('reports', $packageConfig['packages']);
+        } else {
+            $this->assertSame('active', $packageConfig['packages']['reports']['state']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function packageStatesFileIsCreatedFromComposerRun()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            // TODO: find out the reason, why composer cannot be executed using Symfony Process
+            $this->markTestSkipped('Currently does not work on Windows');
+        }
+        $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        @unlink($packageStatesFile);
+        chdir(dirname(dirname(dirname(dirname(__DIR__)))));
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setEnv('TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES', 'yes');
+        $processBuilder->setEnv('TYPO3_CONSOLE_TEST_SETUP', 'yes');
+        $processBuilder->setEnv('TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS', 'yes');
+        $processBuilder->setPrefix('composer');
+        $processBuilder->add('dump-autoload');
+        $processBuilder->add('-vv');
+        $composerProcess = $processBuilder->getProcess();
+        $composerProcess->run();
+        $this->assertTrue($composerProcess->isSuccessful());
+        $this->assertTrue(file_exists($packageStatesFile));
+        $packageConfig = require $packageStatesFile;
+        if ($packageConfig['version'] === 5) {
+            $this->assertArrayHasKey('reports', $packageConfig['packages']);
+        } else {
+            $this->assertSame('active', $packageConfig['packages']['reports']['state']);
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,9 @@ services:
 environment:
   COMPOSER_NO_INTERACTION: 1
   TYPO3_PATH_ROOT: 'c:\t3c\.Build\Web'
-  TYPO3_CONSOLE_DEBUG: 1
+  TYPO3_INSTALL_DB_USER: 'root'
+  TYPO3_INSTALL_DB_PASSWORD: 'Password12!'
+  TYPO3_INSTALL_DB_DBNAME: 'appveyor_console_test'
 
   matrix:
     - TYPO3_VERSION: '~8.6'
@@ -27,9 +29,10 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
 
 init:
-  - SET PATH=c:\php\%PHP_VERSION%;%PATH%
+  - SET PATH=c:\php\%PHP_VERSION%;"C:\Program Files\MySQL\MySQL Server 5.7\bin\";%PATH%
 
 install:
+  - mysql --version
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
@@ -50,70 +53,13 @@ install:
   - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
   - cd c:\t3c
   - composer require "typo3/cms=%TYPO3_VERSION%" --prefer-dist --no-progress --ansi
+#  - RMDIR c:\t3c\.Build\Web\typo3
+#  - robocopy c:\t3c\.Build\vendor\typo3\cms\typo3 c:\t3c\.Build\Web\typo3 /s /e > NUL
 
 test_script:
   - cd c:\t3c
   - echo %TYPO3_PATH_ROOT%
-  - .Build\bin\phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/
   - SET TYPO3_PATH_ROOT=c:\t3c\.Build\Web
   - echo %TYPO3_PATH_ROOT%
   - DIR %TYPO3_PATH_ROOT%
-  - echo %TYPO3_CONSOLE_DEBUG%
-  - php Scripts/typo3cms
-  - php Scripts/typo3cms install:setup --non-interactive --database-user-name="root" --database-user-password="Password12!" --database-host-name="localhost" --database-port="3306" --database-name="appveyor_test" --admin-user-name="admin" --admin-password="password" --site-name="Appveyor Install" --site-setup-type="createsite"
-#  - echo 'select uid,title from pages limit 1' | typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home
-  - php Scripts/typo3cms help
-  - php Scripts/typo3cms help:autocomplete >nul
-  - php Scripts/typo3cms help:autocomplete bash >nul
-  - php Scripts/typo3cms help:autocomplete zsh >nul
-  - php Scripts/typo3cms backend:lock
-  - php Scripts/typo3cms backend:lock
-  - php Scripts/typo3cms backend:unlock
-  - php Scripts/typo3cms backend:unlock
-  - php Scripts/typo3cms backend:lockforeditors
-  - php Scripts/typo3cms backend:lockforeditors
-  - php Scripts/typo3cms backend:unlockforeditors
-  - php Scripts/typo3cms backend:unlockforeditors
-  - php Scripts/typo3cms cache:flush
-  - php Scripts/typo3cms cache:flushgroups pages
-  - php Scripts/typo3cms cache:flushtags foo
-  - php Scripts/typo3cms cache:flushtags foo pages
-  - php Scripts/typo3cms cache:listgroups
-  - php Scripts/typo3cms cleanup:updatereferenceindex
-  - php Scripts/typo3cms database:updateschema "*" --verbose --dry-run
-  - php Scripts/typo3cms database:updateschema --verbose
-  - php Scripts/typo3cms database:updateschema "*" --verbose
-#  - php Scripts/typo3cms database:export > travis_test.sql
-#  - test $(typo3cms database:export --exclude-tables sys_log | grep "CREATE TABLE" | grep -c sys_log) -eq 0
-#  - echo "SELECT username from be_users where admin=1;" | php Scripts/typo3cms database:import
-#  - echo "DROP DATABASE travis_test;" | php Scripts/typo3cms database:import
-#  - echo "CREATE DATABASE travis_test;" | mysql -uroot && cat travis_test.sql | php Scripts/typo3cms database:import
-#  - php Scripts/typo3cms database:updateschema "*" --verbose
-  - php Scripts/typo3cms frontend:request / >nul
-  - php Scripts/typo3cms documentation:generatexsd "TYPO3\CMS\Fluid\ViewHelpers" >nul
-  - php Scripts/typo3cms configuration:show BE/installToolPassword
-  - php Scripts/typo3cms configuration:showLocal BE/installToolPassword
-  - php Scripts/typo3cms configuration:showActive BE/installToolPassword
-#  - php Scripts/typo3cms configuration:set BE/installToolPassword foobar && grep installToolPassword $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php | grep foobar
-#  - php Scripts/typo3cms configuration:remove BE/installToolPassword --force && grep -qv installToolPassword $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php
-#  - php Scripts/typo3cms configuration:set BE/installToolPassword blablupp && grep installToolPassword $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php | grep blablupp
-#  - php Scripts/typo3cms configuration:set EXTCONF/lang/availableLanguages/1 fr_FR && grep fr_FR $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php
-#  - php Scripts/typo3cms configuration:set EXTCONF/foo/bar baz && grep bar $TYPO3_PATH_ROOT/typo3conf/LocalConfiguration.php | grep baz
-#  - rm -f $TYPO3_PATH_ROOT/typo3conf/PackageStates.php && php Scripts/typo3cms install:generatepackagestates --activate-default && [ -f "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php" ]
-#  - rm -f $TYPO3_PATH_ROOT/typo3conf/PackageStates.php && TYPO3_CONSOLE_FEATURE_GENERATE_PACKAGE_STATES=yes TYPO3_CONSOLE_TEST_SETUP=yes TYPO3_ACTIVATE_DEFAULT_FRAMEWORK_EXTENSIONS=yes composer dump-autoload -vv 2>&1 | grep 'generated PackageStates.php' && [ -f "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php" ]
-#  - grep sys_note "$TYPO3_PATH_ROOT/typo3conf/PackageStates.php"
-#  - rm $TYPO3_PATH_ROOT/typo3temp/index.html && php Scripts/typo3cms install:fixfolderstructure && [ -f "$TYPO3_PATH_ROOT/typo3temp/index.html" ]
-  - php Scripts/typo3cms extension:list
-  - php Scripts/typo3cms extension:list --raw
-#  - php Scripts/typo3cms extension:list --raw | grep extbase
-  - php Scripts/typo3cms extension:list --active --raw
-#  - php Scripts/typo3cms extension:list --active --raw | grep extbase
-  - php Scripts/typo3cms extension:list --inactive --raw
-#  - php Scripts/typo3cms extension:list --inactive --raw | tr '\n' ' ' | grep -v extbase
-#  - cp -r Tests/Functional/Fixtures/ext_test .Build/Web/typo3conf/ext/
-#  - php Scripts/typo3cms extension:activate ext_test && php Scripts/typo3cms cache:flush && php Scripts/typo3cms database:updateschema | grep 'No schema updates were performed'
-#  - php Scripts/typo3cms extension:activate core && php Scripts/typo3cms database:updateschema | grep 'No schema updates were performed'
-#  - php Scripts/typo3cms extension:setup core && php Scripts/typo3cms database:updateschema | grep 'No schema updates were performed'
-#  - php Scripts/typo3cms extension:setupactive && php Scripts/typo3cms database:updateschema | grep 'No schema updates were performed'
-#  - if php Scripts/typo3cms extension:list --raw | grep dbal; then php Scripts/typo3cms extension:activate adodb,dbal && php Scripts/typo3cms database:updateschema | grep 'No schema updates were performed'; fi
-#  - php Scripts/typo3cms extension:removeinactive --force | grep 'The following directories have been removed'
+  - .Build\bin\phpunit

--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,9 @@
     "require-dev": {
         "typo3-console/create-reference-command": "1.0.*@dev",
         "typo3/cms": "^8.7",
+        "symfony/filesystem": "^3.2",
         "nimut/testing-framework": "^1.0",
-        "mikey179/vfsStream": "~1.6.0",
-        "phpunit/phpunit": "~4.8.0"
+        "mikey179/vfsStream": "~1.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<phpunit
+    backupGlobals="true"
+    backupStaticAttributes="false"
+    bootstrap=".Build/vendor/nimut/testing-framework/res/Configuration/UnitTestsBootstrap.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <testsuites>
+        <testsuite name="TYPO3 Console Unit Tests">
+            <directory>./Tests/Unit/*/</directory>
+        </testsuite>
+        <testsuite name="TYPO3 Console Install Command Tests">
+            <directory>./Tests/Functional/Command/Install/</directory>
+        </testsuite>
+        <testsuite name="TYPO3 Console all Command Tests">
+            <directory>./Tests/Functional/*/</directory>
+            <exclude>./Tests/Functional/Command/Install/</exclude>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Use command dispatcher now to execute the commands
and plain PHPUnit to compare the result with the expected result.

This is especially great for Appveyor, as we now have all tests
executed on this platform as well.

Besides that the structure for functional tests is much clearer
and more streamlined.

This change revealed some minor inconsistencies in some commands,
which are fixed as well.