### PR TITLE
requestId must not be longer than 13 characters

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -74,7 +74,7 @@ class ConsoleBootstrap extends Bootstrap
             if (!is_callable([$this, 'setRequestType'])) {
                 $this->defineTypo3RequestTypes();
             }
-            $this->requestId = uniqid('console_request_', true);
+            $this->requestId = substr(md5(uniqid('console_request_', true)), 0, 13);
             $this->initializePackageManagement();
 
             if (!class_exists(RunLevel::class)) {


### PR DESCRIPTION
Changed so requestId is only 13 characters long.

If requestId is longer than 13 characters, inserts into sys_log will fail.