### PR TITLE
[BUGFIX] Improve exception rendering for sub processes

### DIFF
--- a/Classes/Error/ExceptionHandler.php
+++ b/Classes/Error/ExceptionHandler.php
@@ -13,6 +13,8 @@ namespace Helhum\Typo3Console\Error;
  *
  */
 
+use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
+use Helhum\Typo3Console\Mvc\Cli\SubProcessException;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
@@ -54,14 +56,20 @@ class ExceptionHandler
      */
     protected function renderException($exception)
     {
+        if (getenv('TYPO3_CONSOLE_SUB_PROCESS')) {
+            $this->output->getErrorOutput()->write(\json_encode($this->serializeException($exception)));
+            return;
+        }
         $this->output->writeln('');
         $this->outputException($exception);
         $this->output->writeln('');
         $this->outputTrace($exception);
         $previousException = $exception;
+        $level = 0;
         while (($previousException = $previousException->getPrevious()) !== null) {
+            $level++;
             $this->output->writeln('');
-            $this->outputException($previousException);
+            $this->outputException($previousException, $level);
             $this->output->writeln('');
             $this->outputTrace($previousException);
         }
@@ -71,15 +79,32 @@ class ExceptionHandler
      * Output formatted exception.
      *
      * @param \Exception|\Throwable $exception
+     * @param int $level
      */
-    protected function outputException($exception)
+    protected function outputException($exception, $level = 0)
     {
         $exceptionCodeNumber = ($exception->getCode() > 0) ? '#' . $exception->getCode() . ': ' : '';
+        $exceptionClass = get_class($exception);
+        $line = $exception->getLine();
+        $file = $exception->getFile();
+        if ($exception instanceof SubProcessException) {
+            if ($level > 1) {
+                $exceptionClass = str_replace('Sub-process exception: ', sprintf('Sub-process exception (%d): ', $level), $exception->getPreviousExceptionClass());
+            } else {
+                $exceptionClass = 'Sub-process exception: ' . $exception->getPreviousExceptionClass();
+            }
+            $line = $exception->getPreviousExceptionLine();
+            $file = $exception->getPreviousExceptionFile();
+        } elseif ($exception instanceof FailedSubProcessCommandException) {
+            $backtraceSteps = $exception->getTrace();
+            $line = $backtraceSteps[1]['line'];
+            $file = $backtraceSteps[1]['file'];
+        }
 
-        $title = sprintf('[ %s ]', get_class($exception));
+        $title = sprintf('[ %s ]', $exceptionClass);
         $exceptionTitle = sprintf('%s%s', $exceptionCodeNumber, $exception->getMessage());
-        $exceptionFile = sprintf('thrown in file %s', $this->getPossibleShortenedFileName($exception->getFile()));
-        $exceptionLine = sprintf('in line %s', $exception->getLine());
+        $exceptionFile = sprintf('thrown in file %s', $this->getPossibleShortenedFileName($file));
+        $exceptionLine = sprintf('in line %s', $line);
 
         $maxLength = max([strlen($title), strlen($exceptionTitle), strlen($exceptionFile), strlen($exceptionLine)]);
         $this->output->writeln($this->padMessage('', $maxLength));
@@ -88,6 +113,21 @@ class ExceptionHandler
         $this->output->writeln($this->padMessage($exceptionFile, $maxLength));
         $this->output->writeln($this->padMessage($exceptionLine, $maxLength));
         $this->output->writeln($this->padMessage('', $maxLength));
+        if ($exception instanceof FailedSubProcessCommandException) {
+            $this->output->writeln('');
+            $this->output->writeln('<comment>Command line:</comment>');
+            $this->output->writeln($exception->getCommandLine());
+            if ($exception->getOutputMessage()) {
+                $this->output->writeln('');
+                $this->output->writeln('<comment>Command output:</comment>');
+                $this->output->writeln($exception->getOutputMessage());
+            }
+            if ($exception->getErrorMessage()) {
+                $this->output->writeln('');
+                $this->output->writeln('<comment>Command error output:</comment>');
+                $this->output->writeln($exception->getErrorMessage());
+            }
+        }
     }
 
     /**
@@ -99,6 +139,11 @@ class ExceptionHandler
     {
         $this->output->writeln('<comment>Exception trace:</comment>');
         $backtraceSteps = $exception->getTrace();
+        if ($exception instanceof SubProcessException) {
+            $backtraceSteps = $exception->getPreviousExceptionTrace();
+        } elseif ($exception instanceof FailedSubProcessCommandException) {
+            array_shift($backtraceSteps);
+        }
         foreach ($backtraceSteps as $index => $step) {
             $traceLine = '#' . $index . ' ';
             if (isset($backtraceSteps[$index]['class'])) {
@@ -134,9 +179,43 @@ class ExceptionHandler
      */
     protected function getPossibleShortenedFileName($fileName)
     {
+        $fileName = substr($fileName, strlen(dirname(dirname(__DIR__))) + 1);
         $pathPosition = strpos($fileName, 'typo3conf/ext/');
         $pathAndFilename = ($pathPosition !== false) ? substr($fileName, $pathPosition) : $fileName;
         $pathPosition = strpos($pathAndFilename, 'typo3/sysext/');
         return ($pathPosition !== false) ? substr($pathAndFilename, $pathPosition) : $pathAndFilename;
+    }
+
+    /**
+     * @param \Exception|\Throwable $exception
+     * @return array|null
+     */
+    private function serializeException($exception)
+    {
+        $serializedException = null;
+        if ($exception) {
+            $exceptionClass = get_class($exception);
+            $line = $exception->getLine();
+            $file = $exception->getFile();
+            if ($exception instanceof SubProcessException) {
+                $exceptionClass = 'Sub-process exception: ' . $exception->getPreviousExceptionClass();
+                $line = $exception->getPreviousExceptionLine();
+                $file = $exception->getPreviousExceptionFile();
+            } elseif ($exception instanceof FailedSubProcessCommandException) {
+                $backtraceSteps = $exception->getTrace();
+                $line = $backtraceSteps[1]['line'];
+                $file = $backtraceSteps[1]['file'];
+            }
+            $serializedException = [
+                'class' => $exceptionClass,
+                'line' => $line,
+                'file' => $file,
+                'message' => $exception->getMessage(),
+                'code' => $exception->getCode(),
+                'trace' => $exception->getTrace(),
+                'previous' => $this->serializeException($exception->getPrevious()),
+            ];
+        }
+        return $serializedException;
     }
 }

--- a/Classes/Mvc/Cli/FailedSubProcessCommandException.php
+++ b/Classes/Mvc/Cli/FailedSubProcessCommandException.php
@@ -25,9 +25,19 @@ class FailedSubProcessCommandException extends \Exception
     private $command;
 
     /**
+     * @var string
+     */
+    private $commandLine;
+
+    /**
      * @var int
      */
     private $exitCode;
+
+    /**
+     * @var string
+     */
+    private $outputMessage;
 
     /**
      * @var string
@@ -55,28 +65,27 @@ class FailedSubProcessCommandException extends \Exception
      */
     public function __construct($command, $commandLine, $exitCode, $outputMessage, $errorMessage)
     {
-        if (empty($outputMessage . $errorMessage)) {
-            $errorMessage = sprintf(
-                "Executing \"%s\" failed (exit code: \"%d\") with no message\n",
-                $commandLine,
-                $exitCode
-            );
-        } else {
-            $errorMessage = sprintf(
-                "Executing \"%s\" failed (exit code: \"%d\") with message:\n\n\"%s\"\n\nand error:\n\n\"%s\"\n",
-                $commandLine,
-                $exitCode,
-                $outputMessage,
-                $errorMessage
-            );
+        $previousExceptionData = @json_decode($errorMessage, true) ?: null;
+        $previousException = null;
+        if ($previousExceptionData) {
+            $errorMessage = '';
+            $previousException = SubProcessException::createFromArray($previousExceptionData);
         }
+        $exceptionMessage = sprintf(
+            'Executing command "%s" failed (exit code: "%d")',
+            $command,
+            $exitCode
+        );
         parent::__construct(
-            $errorMessage,
-            1485130941
+            $exceptionMessage,
+            1485130941,
+            $previousException
         );
         $this->command = $command;
+        $this->commandLine = $commandLine;
         $this->exitCode = $exitCode;
         $this->errorMessage = $errorMessage;
+        $this->outputMessage = $outputMessage;
     }
 
     /**
@@ -88,11 +97,27 @@ class FailedSubProcessCommandException extends \Exception
     }
 
     /**
+     * @return string
+     */
+    public function getCommandLine()
+    {
+        return $this->commandLine;
+    }
+
+    /**
      * @return int
      */
     public function getExitCode()
     {
         return $this->exitCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutputMessage()
+    {
+        return $this->outputMessage;
     }
 
     /**

--- a/Classes/Mvc/Cli/SubProcessException.php
+++ b/Classes/Mvc/Cli/SubProcessException.php
@@ -1,0 +1,95 @@
+<?php
+namespace Helhum\Typo3Console\Mvc\Cli;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/**
+ * Thrown when a sub process command failed
+ */
+class SubProcessException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $previousExceptionClass;
+
+    /**
+     * @var
+     */
+    private $previousExceptionTrace;
+
+    /**
+     * @var
+     */
+    private $previousExceptionLine;
+
+    /**
+     * @var
+     */
+    private $previousExceptionFile;
+
+    public function __construct($previousExceptionClass, $previousExceptionMessage, $previousExceptionCode, $previousExceptionTrace, $previousExceptionLine, $previousExceptionFile, $previousExceptionData = null)
+    {
+        $previousException = $previousExceptionData ? self::createFromArray($previousExceptionData) : null;
+        parent::__construct($previousExceptionMessage, $previousExceptionCode, $previousException);
+        $this->previousExceptionClass = $previousExceptionClass;
+        $this->previousExceptionTrace = $previousExceptionTrace;
+        $this->previousExceptionLine = $previousExceptionLine;
+        $this->previousExceptionFile = $previousExceptionFile;
+    }
+
+    public static function createFromArray($previousExceptionData)
+    {
+        return new self(
+            $previousExceptionData['class'],
+            $previousExceptionData['message'],
+            $previousExceptionData['code'],
+            $previousExceptionData['trace'],
+            $previousExceptionData['line'],
+            $previousExceptionData['file'],
+            $previousExceptionData['previous']
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPreviousExceptionClass()
+    {
+        return $this->previousExceptionClass;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPreviousExceptionTrace()
+    {
+        return $this->previousExceptionTrace;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPreviousExceptionLine()
+    {
+        return $this->previousExceptionLine;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPreviousExceptionFile()
+    {
+        return $this->previousExceptionFile;
+    }
+}

--- a/Tests/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Functional/Command/CacheCommandControllerTest.php
@@ -53,7 +53,7 @@ class CacheCommandControllerTest extends AbstractCommandTest
             $this->commandDispatcher->executeCommand('cache:flushgroups', ['--groups' => 'foo']);
         } catch (FailedSubProcessCommandException $e) {
             $this->assertSame(1, $e->getExitCode());
-            $this->assertContains('Invalid cache groups "foo".', $e->getErrorMessage());
+            $this->assertContains('Invalid cache groups "foo".', $e->getOutputMessage());
         }
     }
 

--- a/Tests/Functional/Command/UpgradeCommandControllerTest.php
+++ b/Tests/Functional/Command/UpgradeCommandControllerTest.php
@@ -37,7 +37,7 @@ class UpgradeCommandControllerTest extends AbstractCommandTest
             $this->commandDispatcher->executeCommand('upgrade:checkextensionconstraints', ['--typo3-version' => '3.6.0']);
         } catch (FailedSubProcessCommandException $e) {
             $this->assertSame(1, $e->getExitCode());
-            $this->assertContains('"ext_test" requires TYPO3 versions 4.5.0', $e->getErrorMessage());
+            $this->assertContains('"ext_test" requires TYPO3 versions 4.5.0', $e->getOutputMessage());
         }
         $this->commandDispatcher->executeCommand('extension:deactivate', ['--extension-keys' => 'ext_test']);
         $this->removeFixtureExtensionCode('ext_test');


### PR DESCRIPTION
Render failed sub process exceptions in a structured way
which includes output and error output.

Also render exceptions that occurred in the sub process
like previous exceptions including its trace in a readable way.