### PR TITLE
[BUGFIX] Avoid deprecation log entries and notices

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -309,7 +309,9 @@ class ConsoleBootstrap extends Bootstrap
      */
     protected function requireLibraries()
     {
-        @include 'phar://' . __DIR__ . '/../../Libraries/symfony-process.phar/vendor/autoload.php';
+        if (@file_exists($pharFile = dirname(dirname(__DIR__)) . '/Libraries/symfony-process.phar')) {
+            include 'phar://' . $pharFile . '/vendor/autoload.php';
+        }
     }
 
     /**


### PR DESCRIPTION
The bootstrap currently triggers some notices and TYPO3
deprecation log entries (depending on TYPO3 version),
which are now avoided.