### PR TITLE
[BUGFIX] Use correct command identifier in sub process

### DIFF
--- a/Classes/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Install/Upgrade/UpgradeHandling.php
@@ -46,9 +46,14 @@ class UpgradeHandling
     private $upgradeWizardList;
 
     /**
-     * @var ConfigurationService|null
+     * @var ConfigurationService
      */
     private $configurationService;
+
+    /**
+     * @var UpgradeWizardFactory
+     */
+    private $factory;
 
     /**
      * Flag for same process
@@ -68,10 +73,6 @@ class UpgradeHandling
         'compatibility7Extension' => [['name' => 'install', 'type' => 'bool', 'default' => '0']],
         'rtehtmlareaExtension' => [['name' => 'install', 'type' => 'bool', 'default' => '0']],
     ];
-    /**
-     * @var UpgradeWizardFactory|null
-     */
-    private $factory;
 
     /**
      * @param UpgradeWizardFactory|null $factory
@@ -227,7 +228,7 @@ class UpgradeHandling
             $this->initialUpgradeDone = true;
             $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', true);
             $this->silentConfigurationUpgrade->executeSilentConfigurationUpgradesIfNeeded();
-            $this->commandDispatcher->executeCommand('upgrade:executewizard', ['identifier' => DatabaseCharsetUpdate::class]);
+            $this->commandDispatcher->executeCommand('upgrade:wizard', ['identifier' => DatabaseCharsetUpdate::class]);
             $this->commandDispatcher->executeCommand('database:updateschema');
         }
     }


### PR DESCRIPTION
The upgrade:wizard command called for initial upgrade
was wrong, which resulted in it not being executed.

Since we now also check for wrong commands, it is crutial
to use the correct command name here not not make the upgrade fail.