### PR TITLE
[BUGFIX] Ensure initial upgrade is done

### DIFF
--- a/Classes/Install/Upgrade/UpgradeHandling.php
+++ b/Classes/Install/Upgrade/UpgradeHandling.php
@@ -224,9 +224,14 @@ class UpgradeHandling
 
     private function ensureUpgradeIsPossible()
     {
-        if (!$this->initialUpgradeDone && !$this->configurationService->hasActive('EXTCONF/helhum-typo3-console/initialUpgradeDone')) {
+        if (!$this->initialUpgradeDone
+            && (
+                    !$this->configurationService->hasLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone')
+                    || TYPO3_branch !== $this->configurationService->getLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone')
+                )
+        ) {
             $this->initialUpgradeDone = true;
-            $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', true);
+            $this->configurationService->setLocal('EXTCONF/helhum-typo3-console/initialUpgradeDone', TYPO3_branch, 'string');
             $this->silentConfigurationUpgrade->executeSilentConfigurationUpgradesIfNeeded();
             $this->commandDispatcher->executeCommand('upgrade:wizard', ['identifier' => DatabaseCharsetUpdate::class]);
             $this->commandDispatcher->executeCommand('database:updateschema');

--- a/Classes/Service/Configuration/ConfigurationService.php
+++ b/Classes/Service/Configuration/ConfigurationService.php
@@ -157,12 +157,13 @@ class ConfigurationService implements SingletonInterface
      *
      * @param string $path
      * @param mixed $value
+     * @param string $targetType
      * @return bool
      */
-    public function setLocal($path, $value)
+    public function setLocal($path, $value, $targetType = '')
     {
         try {
-            $value = $this->convertToTargetType($path, $value);
+            $value = $this->convertToTargetType($path, $value, $targetType);
             return $this->configurationManager->setLocalConfigurationValueByPath($path, $value);
         } catch (TypesAreNotConvertibleException $e) {
             return false;
@@ -189,12 +190,13 @@ class ConfigurationService implements SingletonInterface
      *
      * @param string $path
      * @param string $value
+     * @param string $targetType
      * @throws TypesAreNotConvertibleException
      * @return bool|float|int|string
      */
-    public function convertToTargetType($path, $value)
+    public function convertToTargetType($path, $value, $targetType = '')
     {
-        $targetType = $this->getType($path);
+        $targetType = $targetType ?: $this->getType($path);
         $actualType = gettype($value);
         if ($actualType !== $targetType) {
             if ($this->isTypeConvertible($targetType, $actualType)) {


### PR DESCRIPTION
When performing an upgrade with multiple steps
(first to TYPO3 7.6 then 8.7), it is necessary to
check if the upgrade was done for a specific TYPO3 branch
not only if performed at all.