### PR TITLE
[FEATURE] Deactivate not compatible extensions on upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
     echo "Running unit and functional tests…";
     .Build/bin/phpunit;
   # This fails when command reference is not up to date
-  - typo3cms commandreference:render && test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
+  - typo3cms commandreference:render > /dev/null 2>&1 && test -z "$(git diff --shortstat 2> /dev/null | tail -n1)";
 
 after_script:
   - >

--- a/Classes/Install/Upgrade/SilentConfigurationUpgrade.php
+++ b/Classes/Install/Upgrade/SilentConfigurationUpgrade.php
@@ -45,8 +45,8 @@ class SilentConfigurationUpgrade
     /**
      * Call silent upgrade class, redirect to self if configuration was changed.
      *
-     * @throws RedirectException
-     * @return void
+     * @throws \UnexpectedValueException
+     * @throws \RuntimeException
      */
     public function executeSilentConfigurationUpgradesIfNeeded()
     {
@@ -64,7 +64,7 @@ class SilentConfigurationUpgrade
                 $redirect = true;
                 $this->configurationManager->exportConfiguration();
                 if ($count > 20) {
-                    throw $e;
+                    throw new \RuntimeException('Too many loops when silently upgrading configuration', 1493897404, $e);
                 }
             }
         } while ($redirect === true);

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -24,7 +24,7 @@ return [
         'typo3_console:database:import' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:database:updateschema' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
         'typo3_console:upgrade:subprocess' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_FULL,
-        'typo3_console:upgrade:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL,
+        'typo3_console:upgrade:*' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_COMPILE,
     ],
     'bootingSteps' => [
         'typo3_console:install:databasedata' => ['helhum.typo3console:database'],

--- a/Tests/Unit/Extension/ExtensionConstraintCheckTest.php
+++ b/Tests/Unit/Extension/ExtensionConstraintCheckTest.php
@@ -1,0 +1,130 @@
+<?php
+namespace Helhum\Typo3Console\Tests\Unit\Extension;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+use Helhum\Typo3Console\Extension\ExtensionConstraintCheck;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Extensionmanager\Utility\EmConfUtility;
+
+class ExtensionConstraintCheckTest extends UnitTestCase
+{
+    public function constraintsDataProvider()
+    {
+        return [
+            'matching constraint' => [
+                '6.2.0 - 7.6.99',
+                '7.6.0',
+                '',
+            ],
+            'matching constraint no upper' => [
+                '6.2.0 - ',
+                '7.6.0',
+                '',
+            ],
+            'matching constraint no lower' => [
+                '- 7.6.99',
+                '4.5.0',
+                '',
+            ],
+            'matching constraint no value' => [
+                '',
+                '4.5.0',
+                '',
+            ],
+            'failing lower constraint' => [
+                '6.2.0 - 7.6.99',
+                '4.5.0',
+                '"dummy" requires TYPO3 versions 6.2.0 - 7.6.99. It is not compatible with TYPO3 version "4.5.0"',
+            ],
+            'failing higher constraint' => [
+                '6.2.0 - 7.6.99',
+                '8.7.0',
+                '"dummy" requires TYPO3 versions 6.2.0 - 7.6.99. It is not compatible with TYPO3 version "8.7.0"',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider constraintsDataProvider
+     * @param string $constraint
+     * @param string $typo3Version
+     * @param string $expectedResult
+     */
+    public function matchConstraintsReturnsCorrectResults($constraint, $typo3Version, $expectedResult)
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('dummy');
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3conf/ext/dummy/');
+
+        $emConfUtilityProphecy = $this->prophesize(EmConfUtility::class);
+        $emConfUtilityProphecy->includeEmConf([
+            'key' => 'dummy',
+            'siteRelPath' => 'typo3conf/ext/dummy/',
+        ])->willReturn(
+            [
+                'constraints' => [
+                    'depends' => [
+                        'typo3' => $constraint,
+                    ],
+                ],
+            ]
+        );
+        $packageManagerProphecy = $this->prophesize(PackageManager::class);
+        $subject = new ExtensionConstraintCheck(
+            $emConfUtilityProphecy->reveal(),
+            $packageManagerProphecy->reveal()
+        );
+
+        $this->assertSame($expectedResult, $subject->matchConstraints($packageProphecy->reveal(), $typo3Version));
+    }
+
+    /**
+     * @test
+     * @dataProvider constraintsDataProvider
+     * @param string $constraint
+     * @param string $typo3Version
+     */
+    public function matchAllConstraintsIgnoresExtensionsNotInExtFolder($constraint, $typo3Version)
+    {
+        $packageProphecy = $this->prophesize(PackageInterface::class);
+        $packageProphecy->getPackageKey()->willReturn('dummy');
+        $packageProphecy->getPackagePath()->willReturn(PATH_site . 'typo3/sysext/dummy/');
+
+        $emConfUtilityProphecy = $this->prophesize(EmConfUtility::class);
+        $emConfUtilityProphecy->includeEmConf(
+            [
+                'key' => 'dummy',
+                'siteRelPath' => 'typo3conf/ext/dummy/',
+            ]
+        )->willReturn(
+            [
+                'constraints' => [
+                    'depends' => [
+                        'typo3' => $constraint,
+                    ],
+                ],
+            ]
+        );
+        $packageManagerProphecy = $this->prophesize(PackageManager::class);
+        $subject = new ExtensionConstraintCheck(
+            $emConfUtilityProphecy->reveal(),
+            $packageManagerProphecy->reveal()
+        );
+
+        $this->assertSame([], $subject->matchAllConstraints([$packageProphecy->reveal()], $typo3Version));
+    }
+}


### PR DESCRIPTION
Before preforming any upgrade command, we now check whether
extensions are found that are marked as incompatible, as well
as individually checking if the basic extension bootstrap
would work.

Any incompatible extension found will be deactivated during this process.

This ensures that the upgrade can complete even if some incompatible
extensions are present in the system.