### PR TITLE
[TASK] Try again to stabilize Appveyor tests

### DIFF
--- a/Classes/Composer/InstallerScript/CopyTypo3Directory.php
+++ b/Classes/Composer/InstallerScript/CopyTypo3Directory.php
@@ -1,0 +1,54 @@
+<?php
+namespace Helhum\Typo3Console\Composer\InstallerScript;
+
+/*
+ * This file is part of the TYPO3 Console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Composer\InstallerScriptInterface;
+use TYPO3\CMS\Composer\Plugin\Config as Typo3Config;
+use TYPO3\CMS\Composer\Plugin\Util\Filesystem;
+
+class CopyTypo3Directory implements InstallerScriptInterface
+{
+    /**
+     * @param ScriptEvent $event
+     * @return bool
+     */
+    public function shouldRun(ScriptEvent $event)
+    {
+        // Only run on Windows and only when we are the root package (made for Appveyor tests)
+        return DIRECTORY_SEPARATOR === '\\' && $event->getComposer()->getPackage()->getName() === 'helhum/typo3-console';
+    }
+
+    /**
+     * @param ScriptEvent $event
+     * @throws \RuntimeException
+     * @return bool
+     * @internal
+     */
+    public function run(ScriptEvent $event)
+    {
+        $io = $event->getIO();
+        $composer = $event->getComposer();
+        $typo3Config = Typo3Config::load($composer);
+        $webDir = $typo3Config->get('web-dir');
+        $typo3Dir = $typo3Config->get('cms-package-dir');
+        if (is_link("$webDir/typo3")) {
+            rmdir("$webDir/typo3");
+            $filesystem = new Filesystem();
+            $filesystem->copy("$typo3Dir/typo3", "$webDir/typo3");
+            $io->write('<comment>Copied typo3 directory to document root</comment>');
+        }
+        return true;
+    }
+}

--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -14,6 +14,7 @@ namespace Helhum\Typo3Console\Composer;
  */
 
 use Composer\Script\Event as ScriptEvent;
+use Helhum\Typo3Console\Composer\InstallerScript\CopyTypo3Directory;
 use Helhum\Typo3Console\Composer\InstallerScript\GeneratePackageStates;
 use Helhum\Typo3Console\Composer\InstallerScript\InstallDummyExtension;
 use Helhum\Typo3Console\Composer\InstallerScript\PopulateCommandConfiguration;
@@ -29,6 +30,7 @@ class InstallerScripts
      * @var array
      */
     private static $scripts = [
+        CopyTypo3Directory::class,
         PopulateCommandConfiguration::class,
         GeneratePackageStates::class,
         InstallDummyExtension::class,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,10 +54,7 @@ install:
 
   - cd c:\t3c
   - composer require "typo3/cms=%TYPO3_VERSION%" --prefer-dist --no-progress --ansi
-  - RMDIR %TYPO3_PATH_ROOT%\typo3
-  - mklink /d %TYPO3_PATH_ROOT%\typo3 ..\vendor\typo3\cms\typo3
   - DIR %TYPO3_PATH_ROOT%
-#  - robocopy c:\t3c\.Build\vendor\typo3\cms\typo3 c:\t3c\.Build\Web\typo3 /s /e > NUL
 
 test_script:
   - cd c:\t3c


### PR DESCRIPTION
We assume that tests on Appveyor fail because of strange
side effects with symlinks on Windows.

We now copy the TYPO3 directory instead of symlinking it
to be sure this is not the reason.