### PR TITLE
[BUGFIX] Do not call unavailable bootstrap method

### DIFF
--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -159,7 +159,13 @@ class Scripts
      */
     public static function initializePersistence(ConsoleBootstrap $bootstrap)
     {
-        $bootstrap->loadExtensionTables();
+        if (is_callable([$bootstrap, 'loadExtTables'])) {
+            $bootstrap->loadBaseTca();
+            $bootstrap->loadExtTables();
+        } else {
+            // @deprecated can be removed once TYPO3 7.6 support is removed
+            $bootstrap->loadExtensionTables();
+        }
     }
 
     /**

--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -370,7 +370,10 @@ class ConsoleBootstrap extends Bootstrap
         if (is_callable([$this, 'defineDatabaseConstants'])) {
             $this->defineDatabaseConstants();
         }
-        $this->initializeTypo3DbGlobal();
+        // @deprecated can be removed if TYPO3 7 support is removed
+        if (is_callable([$this, 'initializeTypo3DbGlobal'])) {
+            $this->initializeTypo3DbGlobal();
+        }
     }
 
     protected function flushOutputBuffers()


### PR DESCRIPTION
On current TYPO3 master TYPO3_DB is not available any more,
neither the DataBaseConnection class is.