### PR TITLE
[BUGFIX] Only activate default exts in non composer mode

### DIFF
--- a/Classes/Install/PackageStatesGenerator.php
+++ b/Classes/Install/PackageStatesGenerator.php
@@ -15,6 +15,7 @@ namespace Helhum\Typo3Console\Install;
 
 use Helhum\Typo3Console\Package\UncachedPackageManager;
 use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
@@ -45,6 +46,7 @@ class PackageStatesGenerator
      */
     public function generate(array $frameworkExtensionsToActivate = [], $activateDefaultExtensions = false, array $excludedExtensions = [])
     {
+        $this->ensureDirectoryExists(PATH_site . 'typo3conf');
         $this->packageManager->scanAvailablePackages();
         foreach ($this->packageManager->getAvailablePackages() as $package) {
             if (
@@ -66,5 +68,15 @@ class PackageStatesGenerator
         }
         $this->packageManager->forceSortAndSavePackageStates();
         return $this->packageManager->getActivePackages();
+    }
+
+    /**
+     * @param string $directory
+     */
+    private function ensureDirectoryExists($directory)
+    {
+        if (!is_dir($directory)) {
+            GeneralUtility::mkdir_deep(rtrim($directory, '/\\') . '/');
+        }
     }
 }

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -165,6 +165,9 @@ class CommandDispatcher
                 $dashedName = preg_replace('/([A-Z][a-z0-9]+)/', '$1-', $dashedName);
                 $dashedName = '--' . strtolower(substr($dashedName, 0, -1));
             }
+            if (is_array($argumentValue)) {
+                $argumentValue = implode(',', $argumentValue);
+            }
             if (strpos($argumentValue, '=') !== false) {
                 // Big WTF in argument parsing here
                 // If the value contains a = we need to separate the name and value with a = ourselves

--- a/Tests/Functional/Command/Install/InstallCommandControllerTest.php
+++ b/Tests/Functional/Command/Install/InstallCommandControllerTest.php
@@ -100,15 +100,12 @@ class InstallCommandControllerTest extends AbstractCommandTest
     public function packageStatesFileIsCreatedWithDefaultPackages()
     {
         $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        copy($packageStatesFile, $packageStatesFile . '_');
         @unlink($packageStatesFile);
-        $this->commandDispatcher->executeCommand(
-            'install:generatepackagestates',
-            [
-                '--activate-default' => true,
-            ]
-        );
+        $this->commandDispatcher->executeCommand('install:generatepackagestates', ['--activate-default' => true]);
         $this->assertTrue(file_exists($packageStatesFile));
         $packageConfig = require $packageStatesFile;
+        copy($packageStatesFile . '_', $packageStatesFile);
         if ($packageConfig['version'] === 5) {
             $this->assertArrayHasKey('reports', $packageConfig['packages']);
         } else {
@@ -122,6 +119,7 @@ class InstallCommandControllerTest extends AbstractCommandTest
     public function packageStatesFileIsCreatedFromComposerRun()
     {
         $packageStatesFile = getenv('TYPO3_PATH_ROOT') . '/typo3conf/PackageStates.php';
+        copy($packageStatesFile, $packageStatesFile . '_');
         @unlink($packageStatesFile);
 
         $this->executeComposerCommand(
@@ -138,6 +136,7 @@ class InstallCommandControllerTest extends AbstractCommandTest
 
         $this->assertTrue(file_exists($packageStatesFile));
         $packageConfig = require $packageStatesFile;
+        copy($packageStatesFile . '_', $packageStatesFile);
         if ($packageConfig['version'] === 5) {
             $this->assertArrayHasKey('reports', $packageConfig['packages']);
         } else {


### PR DESCRIPTION
Also ensure that a package states file exists that reflects
the defined set of system extensions, but no third party extensions,
to avoid interference during the setup.

Besides that in the end re-create the package states file again,
flush caches and set up all extensions properly.

The end result will be a clean and desired state.