### PR TITLE
[BUGFIX] Activate extensions after TYPO3 setup

### DIFF
--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -134,7 +134,7 @@ class CliSetupRequestHandler
 
         // The TYPO3 installation process does not take care of setting up all extensions properly,
         // so we do it manually here.
-        unset($packageStatesArguments['excludedExtensions']);
+        unset($packageStatesArguments['--excluded-extensions']);
         $this->commandDispatcher->executeCommand('install:generatepackagestates', $packageStatesArguments);
         // Flush caches, as the extension list has changed
         $this->commandDispatcher->executeCommand('cache:flush', ['--force' => true]);


### PR DESCRIPTION
Due to unsetting a wrong key, local extensions were
excluded from being activated after a setup.

Use the correct key to make it work again