### PR TITLE
[BUGFIX] Mitigate invalid constraints error during install

### DIFF
--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -17,6 +17,7 @@ use Helhum\Typo3Console\Core\ConsoleBootstrap;
 use Helhum\Typo3Console\Mvc\Cli\CommandDispatcher;
 use Helhum\Typo3Console\Mvc\Cli\CommandManager;
 use Helhum\Typo3Console\Mvc\Cli\ConsoleOutput;
+use Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException;
 use TYPO3\CMS\Extbase\Mvc\Cli\CommandArgumentDefinition;
 use TYPO3\CMS\Extbase\Mvc\Controller\Argument;
 use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
@@ -134,8 +135,18 @@ class CliSetupRequestHandler
 
         // The TYPO3 installation process does not take care of setting up all extensions properly,
         // so we do it manually here.
-        unset($packageStatesArguments['--excluded-extensions']);
-        $this->commandDispatcher->executeCommand('install:generatepackagestates', $packageStatesArguments);
+        try {
+            $this->commandDispatcher->executeCommand('install:generatepackagestates', array_diff_key($packageStatesArguments, ['--excluded-extensions' => '']));
+        } catch (FailedSubProcessCommandException $e) {
+            // There are very likely broken extensions or extensions with invalid dependencies
+            // Therefore we fall back to TYPO3 standard behaviour and only install default TYPO3 core extensions
+            // @deprecated in 4.6, will be removed in 5.0.0
+            $packageStatesArguments['--activate-default'] = true;
+            $this->commandDispatcher->executeCommand('install:generatepackagestates', $packageStatesArguments);
+            $this->output->outputLine('<warning>An error occurred while generating PackageStates.php</warning>');
+            $this->output->outputLine('<warning>Most likely you have missed correctly specifying depedencies to typo3/cms-* packages</warning>');
+            $this->output->outputLine('<warning>The error message was "%s"</warning>', [$e->getPrevious()->getMessage()]);
+        }
         // Flush caches, as the extension list has changed
         $this->commandDispatcher->executeCommand('cache:flush', ['--force' => true]);
         $this->commandDispatcher->executeCommand('extension:setupactive');


### PR DESCRIPTION
When extensions do not specify their dependency to TYPO3 core extensions
in a composer.json or are not installed via composer, it can happen
that generating PackageStates.php fails when doing install:setup

Since this can be considered a breaking change, we mitigate this
case now by gracefully falling back to generating a PackageStates.php
like TYPO3 does in the web installer, where only core extensions
are activated.

Fixes: #515