### PR TITLE
[BUGFIX] Don't try to flush DB caches after install

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -49,11 +49,16 @@ class CacheCommandController extends CommandController
      * Flushes TYPO3 core caches first and after that, flushes caches from extensions.
      *
      * @param bool $force Cache is forcibly flushed (low level operations are performed)
+     * @param bool $filesOnly Only file caches are flushed (low level operations are performed)
      * @throws \Helhum\Typo3Console\Mvc\Cli\FailedSubProcessCommandException
      */
-    public function flushCommand($force = false)
+    public function flushCommand($force = false, $filesOnly = false)
     {
-        $this->cacheService->flush($force);
+        $this->cacheService->flush($force, $filesOnly);
+        if ($filesOnly) {
+            $this->outputLine('Force flushed file caches.');
+            return;
+        }
         $this->commandDispatcher->executeCommand('cache:flushcomplete');
         $this->outputLine(sprintf('%slushed all caches.', $force ? 'Force f' : 'F'));
     }

--- a/Classes/Install/CliSetupRequestHandler.php
+++ b/Classes/Install/CliSetupRequestHandler.php
@@ -148,7 +148,7 @@ class CliSetupRequestHandler
             $this->output->outputLine('<warning>The error message was "%s"</warning>', [$e->getPrevious()->getMessage()]);
         }
         // Flush caches, as the extension list has changed
-        $this->commandDispatcher->executeCommand('cache:flush', ['--force' => true]);
+        $this->commandDispatcher->executeCommand('cache:flush', ['--files-only' => true]);
         $this->commandDispatcher->executeCommand('extension:setupactive');
     }
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -159,6 +159,8 @@ Options
 
 ``--force``
   Cache is forcibly flushed (low level operations are performed)
+``--files-only``
+  Only file caches are flushed (low level operations are performed)
 
 
 

--- a/Tests/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Functional/Command/CacheCommandControllerTest.php
@@ -38,6 +38,15 @@ class CacheCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function fileCachesCanBeForceFlushedFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flush', ['--files-only' => true]);
+        $this->assertSame('Force flushed file caches.', $output);
+    }
+
+    /**
+     * @test
+     */
     public function cacheGroupsCanBeFlushed()
     {
         $output = $this->commandDispatcher->executeCommand('cache:flushgroups', ['--groups' => 'pages']);


### PR DESCRIPTION
After TYPO3 setup finished, it is necessary to flush
caches so that the extension setup catches all extensions
properly. However extensions mit ship with extra DB caches
so that the two fold cache flush fails with cf_ table
does not exist.

Therefore we need to only flush the ext_localconf file cache
only to avoid this error, but include all extension properly
for extension:setupactive

Fixes #519