### PR TITLE
[BUGFIX] Respect cache config when flushing file caches only

### DIFF
--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -160,7 +160,7 @@ Options
 ``--force``
   Cache is forcibly flushed (low level operations are performed)
 ``--files-only``
-  Only file caches are flushed (low level operations are performed)
+  Only file caches are flushed
 
 
 

--- a/Tests/Functional/Command/CacheCommandControllerTest.php
+++ b/Tests/Functional/Command/CacheCommandControllerTest.php
@@ -38,10 +38,19 @@ class CacheCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
-    public function fileCachesCanBeForceFlushedFlushed()
+    public function fileCachesCanBeFlushed()
     {
         $output = $this->commandDispatcher->executeCommand('cache:flush', ['--files-only' => true]);
-        $this->assertSame('Force flushed file caches.', $output);
+        $this->assertSame('Flushed all file caches.', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function fileCachesCanBeForceFlushedFlushed()
+    {
+        $output = $this->commandDispatcher->executeCommand('cache:flush', ['--files-only' => true, '--force' => true]);
+        $this->assertSame('Force flushed all file caches.', $output);
     }
 
     /**


### PR DESCRIPTION
Previously flushing file caches was only done by performing
low level operations.

Now we also allow flushing file caches using the cache manager API.

Fixes #522