### PR TITLE
[BUGFIX] Fix hang and TypeError when invoking `database:import` through the symfony/console PHP API

### DIFF
--- a/Classes/Console/Command/Database/DatabaseImportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseImportCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DatabaseImportCommand extends Command
@@ -96,7 +97,9 @@ EOH
         $mysqlCommand = new MysqlCommand($this->connectionConfiguration->build($connection), $output);
         $exitCode = $mysqlCommand->mysql(
             array_merge($interactive ? [] : ['--skip-column-names'], $additionalMysqlArguments),
-            STDIN,
+            ($input instanceof StreamableInputInterface)
+                ? ($input->getStream() ?? STDIN)
+                : STDIN,
             null,
             $interactive
         );

--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -16,6 +16,8 @@ namespace Helhum\Typo3Console\Database\Process;
 
 use Helhum\Typo3Console\Mvc\Cli\InteractiveProcess;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 class MysqlCommand
@@ -35,7 +37,7 @@ class MysqlCommand
      */
     private $output;
 
-    public function __construct(array $dbConfig, ?ConsoleOutput $output = null)
+    public function __construct(array $dbConfig, ?OutputInterface $output = null)
     {
         $this->dbConfig = $dbConfig;
         $this->output = $output ?: new ConsoleOutput(); // output being optional is @deprecated. Will become required in 6.0
@@ -89,9 +91,12 @@ class MysqlCommand
         if (!is_callable($outputCallback)) {
             $outputCallback = function ($type, $data) {
                 if (Process::OUT === $type) {
-                    echo $data;
+                    $this->output->write($data, false, OutputInterface::OUTPUT_RAW);
                 } elseif (Process::ERR === $type) {
-                    $this->output->getErrorOutput()->write($data);
+                    $errorOutput = $this->output instanceof ConsoleOutputInterface
+                        ? $this->output->getErrorOutput()
+                        : $this->output;
+                    $errorOutput->write($data);
                 }
             };
         }

--- a/Packages/SqlCommand/src/Command/SqlCommand.php
+++ b/Packages/SqlCommand/src/Command/SqlCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SqlCommand extends Command
@@ -42,8 +43,12 @@ class SqlCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $inputStream = ($input instanceof StreamableInputInterface)
+            ? ($input->getStream() ?? STDIN)
+            : STDIN;
+
         $sql = '';
-        while ($f = fgets(STDIN)) {
+        while ($f = fgets($inputStream)) {
             $sql .= $f;
         }
 

--- a/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
+++ b/Tests/Console/Functional/Command/DatabaseCommandControllerTest.php
@@ -165,6 +165,17 @@ class DatabaseCommandControllerTest extends AbstractCommandTest
     /**
      * @test
      */
+    public function sqlCanBeImportedWithSpecifiedConnectionAndSpecialSymfonyFormattingInstructions()
+    {
+        $this->skipOnSqlite();
+        $sql = 'SELECT "<error>I shouldn\'t be styled because I\'m user data</error>";';
+        $output = $this->executeConsoleCommand('database:import', ['--connection', 'Default'], [], $sql);
+        $this->assertSame('<error>I shouldn\'t be styled because I\'m user data</error>', $output);
+    }
+
+    /**
+     * @test
+     */
     public function databaseImportFailsWithNotExistingConnection()
     {
         $this->skipOnSqlite();


### PR DESCRIPTION
Fix a hang (indefinite wait) and a PHP runtime TypeError that occurred when invoking `database:import` via PHP-code inside another TYPO3 console command with `ArrayInput`.

[A reproduction example is available in another github project](https://github.com/adamkoppede/typo3-console-in-process-command-test-cases) because I don't know how to integrate it into this project's testing framework.