### PR TITLE
add (Opt.)Arg. `WebServerConfig` @ `fixfolderstructure`

### DIFF
--- a/Classes/Console/Command/Install/InstallFixFolderStructureCommand.php
+++ b/Classes/Console/Command/Install/InstallFixFolderStructureCommand.php
@@ -15,10 +15,12 @@ namespace Helhum\Typo3Console\Command\Install;
  */
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\FolderStructure\DefaultFactory;
+use TYPO3\CMS\Install\WebserverType;
 
 class InstallFixFolderStructureCommand extends Command
 {
@@ -31,6 +33,12 @@ Automatically create files and folders, required for a TYPO3 installation.
 
 This command creates the required folder structure needed for TYPO3 including extensions.
 EOH
+        );
+        $this->addArgument(
+            'webServerConfig',
+            InputArgument::OPTIONAL,
+            'Web server config file to install in document root (`none`, `apache`, `iis`)',
+            'none'
         );
     }
 
@@ -46,7 +54,7 @@ EOH
         unset($GLOBALS['BE_USER']);
         $folderStructureFactory = GeneralUtility::makeInstance(DefaultFactory::class);
         $messages = $folderStructureFactory
-            ->getStructure()
+            ->getStructure(WebserverType::fromType($input->getArgument('webServerConfig')))
             ->fix()
             ->getAllMessagesAndFlush();
 

--- a/Documentation/CommandReference/InstallFixfolderstructure.rst
+++ b/Documentation/CommandReference/InstallFixfolderstructure.rst
@@ -17,6 +17,12 @@ Automatically create files and folders, required for a TYPO3 installation.
 
 This command creates the required folder structure needed for TYPO3 including extensions.
 
+Arguments
+=========
+
+`webServerConfig`
+   Web server config file to install in document root (`none`, `apache`, `iis`)
+
 
 
 


### PR DESCRIPTION
missing `.htaccess` will not be "fix'd" w/o @ https://github.com/TYPO3/typo3/blob/197c2f7d0d36f502a2449156880a83a216db6a11/typo3/sysext/install/Classes/FolderStructure/DefaultFactory.php#L99-L113

fyi/ technically [`none`](https://github.com/search?q=repo%3ATYPO3-Console%2FTYPO3-Console%20%60none%60&type=code) is [`other`](https://github.com/TYPO3/typo3/blob/197c2f7d0d36f502a2449156880a83a216db6a11/typo3/sysext/install/Classes/WebserverType.php#L27-L29)  ;)
