### PR TITLE
[TASK] Database commands use now parsed configurations

### DIFF
--- a/Classes/Console/Command/Database/DatabaseExportCommand.php
+++ b/Classes/Console/Command/Database/DatabaseExportCommand.php
@@ -16,14 +16,11 @@ namespace Helhum\Typo3Console\Command\Database;
 
 use Helhum\Typo3Console\Database\Configuration\ConnectionConfiguration;
 use Helhum\Typo3Console\Database\Process\MysqlCommand;
-use Helhum\Typo3Console\Database\Schema\TableMatcher;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class DatabaseExportCommand extends Command
 {
@@ -127,20 +124,10 @@ EOH
             $arguments[] = '--verbose';
         }
 
-        foreach ($this->matchTables($excludes, $mysqlConnectionName) as $table) {
+        foreach ($this->connectionConfiguration->matchTables($excludes, $mysqlConnectionName) as $table) {
             $arguments[] = sprintf('--ignore-table=%s.%s', $dbConfig['dbname'], $table);
         }
 
         return $arguments;
-    }
-
-    private function matchTables(array $excludes, string $connection): array
-    {
-        if (empty($excludes)) {
-            return [];
-        }
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionByName($connection);
-
-        return (new TableMatcher())->match($connection, ...$excludes);
     }
 }

--- a/Classes/Console/Database/Configuration/ConnectionConfiguration.php
+++ b/Classes/Console/Database/Configuration/ConnectionConfiguration.php
@@ -14,32 +14,41 @@ namespace Helhum\Typo3Console\Database\Configuration;
  *
  */
 
+use Helhum\Typo3Console\Database\Schema\TableMatcher;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 class ConnectionConfiguration
 {
     /**
      * Returns a normalized DB configuration array
-     *
-     * @param string|null $name
-     * @return array
      */
-    public function build(?string $name = null): array
+    public function build(string $connectionName = 'Default'): array
     {
-        if ($name === null) {
-            return $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
-        }
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionByName($connectionName);
 
-        return $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][$name];
+        return $connection->getParams();
     }
 
     public function getAvailableConnectionNames(string $type): array
     {
-        return array_keys(
-            array_filter(
-                $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'],
-                function (array $connectionConfig) use ($type) {
-                    return strpos($connectionConfig['driver'] ?? '', $type) !== false;
-                }
-            )
+        return array_filter(
+            GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionNames(),
+            function (string $connectionName) use ($type) {
+                $driverName = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionByName($connectionName)->getParams()['driver'] ?? '';
+
+                return strpos($driverName, $type) !== false;
+            }
         );
+    }
+
+    public function matchTables(array $excludes, string $connectionName): array
+    {
+        if (empty($excludes)) {
+            return [];
+        }
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionByName($connectionName);
+
+        return (new TableMatcher())->match($connection, ...$excludes);
     }
 }


### PR DESCRIPTION
Deriving the connection params from the settings array is cumbersome and leads to duplicate code. Improvements to the original code, like the introduction of a DSN parser leads to unwanted effects. Further the settings array global feels more like an implementation detail than a contract.

As the connection objects are already used anyways for table matching it's just consistent to use them for extracting the connection params.

This change extracts the connection params from the connection itself.