### PR TITLE
Use --skip-ssl when connecting unencrypted

### DIFF
--- a/Classes/Console/Database/Process/MysqlCommand.php
+++ b/Classes/Console/Database/Process/MysqlCommand.php
@@ -123,6 +123,8 @@ class MysqlCommand
         }
         if (isset($this->dbConfig['driverOptions']['flags']) && (int)$this->dbConfig['driverOptions']['flags'] === MYSQLI_CLIENT_SSL) {
             $arguments[] = '--ssl';
+        } else {
+            $arguments[] = '--skip-ssl';
         }
         $arguments[] = $this->dbConfig['dbname'];
 


### PR DESCRIPTION
mysql command recently switched to use SSL as default. So when connection unencrypted you now need to specifiy --skip-ssl explicitly.

Closes #1215 